### PR TITLE
Bandwidth reduction during polling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+Version 7.0.0
+=============
+
+ * Break: `AferoBridgeV1.fetch_data` has been replaced with `AferoBridgeV1.fetch_discovery_data`
+ * Implement `AferoBridgeV1.fetch_all_device_states` that queries all known device states
+ * Reduce the total bandwidth during polling by querying only device state
+
 Version 6.2.0
 =============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aioafero"
-version = "6.2.0"
+version = "7.0.0"
 dependencies = [
   "aiohttp",
   "beautifulsoup4",

--- a/src/aioafero/v1/__init__.py
+++ b/src/aioafero/v1/__init__.py
@@ -163,7 +163,7 @@ class AferoBridgeV1:
         self._adhoc_tasks: list[asyncio.Task] = []
         # Data Updater
         self._events: EventStream = EventStream(
-            self, polling_interval, poll_version, discovery_internval=discovery_interval
+            self, polling_interval, poll_version, discovery_interval=discovery_interval
         )
         # Data Controllers
         self._controllers: dict[str, BaseResourcesController] = {}

--- a/src/aioafero/v1/__init__.py
+++ b/src/aioafero/v1/__init__.py
@@ -102,7 +102,9 @@ class AferoBridgeV1:
     :param session: An optional `aiohttp.ClientSession` to use for requests.
         If not provided, a new session will be created.
     :param polling_interval: The interval in seconds between polling the Afero API
-        for device state updates. Defaults to 30.
+        for device state updates. Defaults to 30 seconds.
+    :param discovery_interval: The interval in seconds between polling the Afero API
+        for new devices. Defaults to 3600 seconds (1 hour).
     :param afero_client: The Afero client identifier (e.g., "hubspace", "myko").
         Defaults to "hubspace".
     :param hide_secrets: If True, sensitive information will be redacted from logs.
@@ -125,6 +127,7 @@ class AferoBridgeV1:
         refresh_token: str | None = None,
         session: aiohttp.ClientSession | None = None,
         polling_interval: int = 30,
+        discovery_interval: int = 3600,
         afero_client: str | None = "hubspace",
         hide_secrets: bool = True,
         poll_version: bool = True,
@@ -159,7 +162,9 @@ class AferoBridgeV1:
         self._scheduled_tasks: list[asyncio.Task] = []
         self._adhoc_tasks: list[asyncio.Task] = []
         # Data Updater
-        self._events: EventStream = EventStream(self, polling_interval, poll_version)
+        self._events: EventStream = EventStream(
+            self, polling_interval, poll_version, discovery_internval=discovery_interval
+        )
         # Data Controllers
         self._controllers: dict[str, BaseResourcesController] = {}
         self.add_controller("devices", DeviceController)
@@ -437,15 +442,46 @@ class AferoBridgeV1:
         task = asyncio.create_task(self._fetch_device_states(device_id))
         self.add_job(task)
         await task
+        return task.result()[1]
+
+    async def fetch_all_device_states(self) -> list[AferoDevice]:
+        """Query the API for all known device states.
+
+        :return: A list of `AferoDevice` objects with updated states.
+        """
+        task = asyncio.create_task(self._fetch_all_device_states())
+        self.add_job(task)
+        await task
         return task.result()
 
-    async def _fetch_device_states(self, device_id) -> list[dict[Any, str]]:
+    async def _fetch_all_device_states(self) -> list[AferoDevice]:
+        """Query the API for all known device states."""
+        # known_devs keeps track of all devices, while .devices is only "parent" items
+        device_ids = list(self._known_devs.keys())
+        tasks = [self._fetch_device_states(dev_id) for dev_id in device_ids]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        updated_devices: list[AferoDevice] = []
+        for result in results:
+            if isinstance(result, Exception):
+                self.logger.warning("Unable to fetch states: %s", result)
+                continue
+            device_id, states = result
+            try:
+                device = self.get_afero_device(device_id)
+            except DeviceNotFound:
+                self.logger.warning("Device %s not found in cache", device_id)
+                continue
+            device.states = states
+            updated_devices.append(device)
+        return updated_devices
+
+    async def _fetch_device_states(self, device_id) -> tuple[str, list[dict[Any, str]]]:
         """Query the API for new device states."""
         self.logger.debug("Querying the API for updated states for %s", device_id)
         headers = {
             "host": v1_const.AFERO_CLIENTS[self._afero_client]["API_DATA_HOST"],
         }
-        params = {"expansions": "state,capabilities,semantics"}
         url = self.generate_api_url(
             v1_const.AFERO_GENERICS["API_DEVICE_STATE_ENDPOINT"].format(
                 self.account_id, device_id
@@ -455,7 +491,6 @@ class AferoBridgeV1:
             "get",
             url,
             headers=headers,
-            params=params,
         )
         res.raise_for_status()
         data = await res.json()
@@ -465,7 +500,7 @@ class AferoBridgeV1:
                 states.append(AferoState(**state))
             except TypeError:
                 continue
-        return states
+        return data["metadeviceId"], states
 
     async def get_device_version(self, device_id: str) -> dict:
         """Query the API for device version information.

--- a/src/aioafero/v1/__init__.py
+++ b/src/aioafero/v1/__init__.py
@@ -379,7 +379,7 @@ class AferoBridgeV1:
             self.add_job(asyncio.create_task(self.events.initialize()))
             self.add_job(asyncio.create_task(self.events.wait_for_first_poll()))
 
-    async def fetch_data(self, version_poll=False) -> list[dict[Any, str]]:
+    async def fetch_discovery_data(self, version_poll=False) -> list[dict[Any, str]]:
         """Query the API for all device data.
 
         :param version_poll: If True, also poll for device version information.
@@ -612,4 +612,4 @@ class AferoBridgeV1:
         """
         if self.temperature_unit != temperature_unit:
             self.temperature_unit = temperature_unit
-            self.add_job(asyncio.create_task(self.events.perform_poll()))
+            self.add_job(asyncio.create_task(self.events.perform_discovery_poll()))

--- a/src/aioafero/v1/controllers/base.py
+++ b/src/aioafero/v1/controllers/base.py
@@ -529,7 +529,9 @@ class BaseResourcesController(Generic[AferoResource]):
             return res
         return None
 
-    def generate_update_dev(self, device_id: str, states: list[AferoState]) -> dict:
+    def generate_update_dev(
+        self, device_id: str, states: list[AferoState]
+    ) -> AferoDevice:
         """Generate update data for the event controller."""
         afero_dev = self._bridge.get_afero_device(device_id)
         afero_dev.states = states

--- a/src/aioafero/v1/controllers/event.py
+++ b/src/aioafero/v1/controllers/event.py
@@ -72,7 +72,11 @@ class EventStream:
     """
 
     def __init__(
-        self, bridge: "AferoBridgeV1", polling_interval: int, poll_version: bool
+        self,
+        bridge: "AferoBridgeV1",
+        polling_interval: int,
+        poll_version: bool,
+        discovery_internval: int = 60 * 60 * 1,
     ) -> None:
         """Initialize instance."""
         self._bridge = bridge
@@ -83,6 +87,7 @@ class EventStream:
         self._subscribers: list[EventSubscriptionType] = []
         self._logger = bridge.logger.getChild("events")
         self._polling_interval: int = polling_interval
+        self._discovery_interval: int = discovery_internval
         self._multiple_device_finder: dict[str, callable] = {}
         self._version_poll_time: datetime.datetime | None = None
         self._version_poll_enabled: bool = poll_version
@@ -137,12 +142,12 @@ class EventStream:
     async def initialize(self) -> None:
         """Start the polling processes."""
         if len(self._scheduled_tasks) == 0:
-            await self.initialize_reader()
+            await self.initialize_discovery()
             await self.initialize_processor()
 
-    async def initialize_reader(self) -> None:
+    async def initialize_discovery(self) -> None:
         """Initialize gathering data from Afero API."""
-        self._scheduled_tasks.append(asyncio.create_task(self.__event_reader()))
+        self._scheduled_tasks.append(asyncio.create_task(self.__event_discovery()))
 
     async def initialize_processor(self) -> None:
         """Initialize the processor."""
@@ -254,12 +259,14 @@ class EventStream:
             self.emit(EventType.DISCONNECTED)
         await asyncio.sleep(backoff_time)
 
-    async def gather_data(self) -> list[dict[Any, str]]:
+    async def gather_discovery_data(self) -> list[dict[Any, str]]:
         """Gather all data from the Afero IoT API."""
         consecutive_http_errors = 0
         while True:
             try:
-                data = await self._bridge.fetch_data(version_poll=self.poll_version)
+                data = await self._bridge.fetch_discovery_data(
+                    version_poll=self.poll_version
+                )
             except TimeoutError:
                 self._logger.warning("Timeout when contacting Afero IoT API.")
                 await self.process_backoff(consecutive_http_errors)
@@ -389,10 +396,10 @@ class EventStream:
                 )
                 self._bridge.remove_device(dev_id)
 
-    async def perform_poll(self) -> None:
+    async def perform_discovery_poll(self) -> None:
         """Poll Afero IoT and generate the required events."""
         try:
-            data = await self.gather_data()
+            data = await self.gather_discovery_data()
         except Exception:  # noqa: BLE001
             self._status = EventStreamStatus.DISCONNECTED
             self.emit(EventType.DISCONNECTED)
@@ -403,12 +410,12 @@ class EventStream:
                 self._logger.exception("Unable to process Afero IoT data. %s", data)
             self._first_poll_completed = True
 
-    async def __event_reader(self) -> None:
+    async def __event_discovery(self) -> None:
         """Poll the current states."""
         self._status = EventStreamStatus.CONNECTING
         while True:
-            await self.perform_poll()
-            await asyncio.sleep(self._polling_interval)
+            await self.perform_discovery_poll()
+            await asyncio.sleep(self._discovery_interval)
 
     async def process_event(self):
         """Process a single event in the queue."""

--- a/src/aioafero/v1/controllers/event.py
+++ b/src/aioafero/v1/controllers/event.py
@@ -76,7 +76,7 @@ class EventStream:
         bridge: "AferoBridgeV1",
         polling_interval: int,
         poll_version: bool,
-        discovery_internval: int = 60 * 60 * 1,
+        discovery_internval: int = 3600,
     ) -> None:
         """Initialize instance."""
         self._bridge = bridge
@@ -143,11 +143,16 @@ class EventStream:
         """Start the polling processes."""
         if len(self._scheduled_tasks) == 0:
             await self.initialize_discovery()
+            await self.initialize_device_polling()
             await self.initialize_processor()
 
     async def initialize_discovery(self) -> None:
         """Initialize gathering data from Afero API."""
         self._scheduled_tasks.append(asyncio.create_task(self.__event_discovery()))
+
+    async def initialize_device_polling(self) -> None:
+        """Initialize gathering device state data from Afero API."""
+        self._scheduled_tasks.append(asyncio.create_task(self.__device_polling()))
 
     async def initialize_processor(self) -> None:
         """Initialize the processor."""
@@ -416,6 +421,27 @@ class EventStream:
         while True:
             await self.perform_discovery_poll()
             await asyncio.sleep(self._discovery_interval)
+
+    async def __device_polling(self) -> None:
+        """Poll the current device states."""
+        while True:
+            await asyncio.sleep(self._polling_interval)
+            if not self._first_poll_completed:
+                continue
+            try:
+                devices = await self._bridge.fetch_all_device_states()
+            except Exception:
+                self._logger.exception("Unable to poll device states")
+                continue
+            for device in await self.split_devices(devices):
+                self._event_queue.put_nowait(
+                    AferoEvent(
+                        type=EventType.RESOURCE_UPDATE_RESPONSE,
+                        device_id=device.id,
+                        device=device,
+                        force_forward=False,
+                    )
+                )
 
     async def process_event(self):
         """Process a single event in the queue."""

--- a/src/aioafero/v1/controllers/event.py
+++ b/src/aioafero/v1/controllers/event.py
@@ -76,7 +76,7 @@ class EventStream:
         bridge: "AferoBridgeV1",
         polling_interval: int,
         poll_version: bool,
-        discovery_internval: int = 3600,
+        discovery_interval: int = 3600,
     ) -> None:
         """Initialize instance."""
         self._bridge = bridge
@@ -87,7 +87,7 @@ class EventStream:
         self._subscribers: list[EventSubscriptionType] = []
         self._logger = bridge.logger.getChild("events")
         self._polling_interval: int = polling_interval
-        self._discovery_interval: int = discovery_internval
+        self._discovery_interval: int = discovery_interval
         self._multiple_device_finder: dict[str, callable] = {}
         self._version_poll_time: datetime.datetime | None = None
         self._version_poll_enabled: bool = poll_version

--- a/src/aioafero/v1/controllers/event.py
+++ b/src/aioafero/v1/controllers/event.py
@@ -226,7 +226,7 @@ class EventStream:
                     and data is not None
                     and (
                         "device" in data
-                        and data["device"]
+                        and hasattr(data["device"], "device_class")
                         and not any(
                             data["device"].device_class == res_filter
                             for res_filter in resource_filter

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,15 +31,15 @@ async def aio_sess() -> aiohttp.ClientSession:
 async def mocked_bridge(mocker, aio_sess) -> AferoBridgeV1:
     """Create a mocked afero bridge to be used in tests."""
     mocker.patch("time.time", return_value=12345)
-    mocker.patch("aioafero.v1.controllers.event.EventStream.gather_data")
+    mocker.patch("aioafero.v1.controllers.event.EventStream.gather_discovery_data")
 
     bridge: AferoBridgeV1 = AferoBridgeV1("username2", "password2")
     mocker.patch.object(bridge, "_account_id", "mocked-account-id")
-    mocker.patch.object(bridge, "fetch_data", return_value=[])
-    mocker.patch.object(bridge.events, "initialize_reader")
+    mocker.patch.object(bridge, "fetch_discovery_data", return_value=[])
+    mocker.patch.object(bridge.events, "initialize_discovery")
     mocker.patch.object(bridge, "request", side_effect=mocker.AsyncMock())
     mocker.patch.object(
-        bridge, "fetch_data", side_effect=mocker.AsyncMock(return_value=[])
+        bridge, "fetch_discovery_data", side_effect=mocker.AsyncMock(return_value=[])
     )
     mocker.patch.object(bridge.events, "_first_poll_completed", True)
     mocker.patch.object(bridge, "_web_session", aio_sess)
@@ -59,7 +59,7 @@ async def mocked_bridge(mocker, aio_sess) -> AferoBridgeV1:
         await task
         raw_data = await bridge.events.generate_events_from_data(data)
         mocker.patch(
-            "aioafero.v1.controllers.event.EventStream.gather_data",
+            "aioafero.v1.controllers.event.EventStream.gather_discovery_data",
             return_value=raw_data,
         )
         await bridge.async_block_until_done()
@@ -68,7 +68,7 @@ async def mocked_bridge(mocker, aio_sess) -> AferoBridgeV1:
     async def generate_devices_from_data(devices: list[AferoDevice]):
         raw_data = [create_hs_raw_from_device(device) for device in devices]
         mocker.patch(
-            "aioafero.v1.controllers.event.EventStream.gather_data",
+            "aioafero.v1.controllers.event.EventStream.gather_discovery_data",
             return_value=raw_data,
         )
         await bridge.events.generate_events_from_data(raw_data)
@@ -111,7 +111,7 @@ def mocked_bridge_req(mocker, aio_sess):
     )
     mocker.patch.object(bridge, "_account_id", "mocked-account-id")
     mocker.patch.object(bridge, "initialize", side_effect=mocker.AsyncMock())
-    mocker.patch.object(bridge, "fetch_data", side_effect=bridge.fetch_data)
+    mocker.patch.object(bridge, "fetch_discovery_data", side_effect=bridge.fetch_discovery_data)
     mocker.patch.object(bridge, "request", side_effect=bridge.request)
     mocker.patch.object(bridge, "_web_session", aio_sess)
     mocker.patch.object(bridge.events, "_first_poll_completed", True)
@@ -135,7 +135,7 @@ def mocked_bridge_req(mocker, aio_sess):
         await task
         raw_data = await bridge.events.generate_events_from_data(data)
         mocker.patch(
-            "aioafero.v1.controllers.event.EventStream.gather_data",
+            "aioafero.v1.controllers.event.EventStream.gather_discovery_data",
             return_value=raw_data,
         )
         await bridge.async_block_until_done()
@@ -144,7 +144,7 @@ def mocked_bridge_req(mocker, aio_sess):
     async def generate_devices_from_data(devices: list[AferoDevice]):
         raw_data = [create_hs_raw_from_device(device) for device in devices]
         mocker.patch(
-            "aioafero.v1.controllers.event.EventStream.gather_data",
+            "aioafero.v1.controllers.event.EventStream.gather_discovery_data",
             return_value=raw_data,
         )
         await bridge.events.generate_events_from_data(raw_data)
@@ -163,7 +163,7 @@ def mocked_bridge_req(mocker, aio_sess):
 async def bridge(mocker):
     bridge = AferoBridgeV1("user", "passwd")
     mocker.patch.object(bridge, "_account_id", "mocked-account-id")
-    mocker.patch.object(bridge, "fetch_data", return_value=[])
+    mocker.patch.object(bridge, "fetch_discovery_data", return_value=[])
     mocker.patch.object(bridge, "request", side_effect=mocker.AsyncMock())
     mocker.patch.object(bridge.events, "_first_poll_completed", True)
     await bridge.initialize()

--- a/tests/v1/controllers/test_event.py
+++ b/tests/v1/controllers/test_event.py
@@ -103,15 +103,15 @@ async def test_subscribe(call, event_filter, resource_filter, expected, mocked_b
 
 
 @pytest.mark.asyncio
-async def test_event_reader_dev_add(bridge, mocker):
+async def test_event_discovery_dev_add(bridge, mocker):
     stream = bridge.events
     stream._subscribers = []
     await stream.stop()
 
     light_raw = utils.get_raw_dump("light-a21-raw.json")
 
-    mocker.patch.object(bridge, "fetch_data", AsyncMock(return_value=light_raw))
-    await stream.initialize_reader()
+    mocker.patch.object(bridge, "fetch_discovery_data", AsyncMock(return_value=light_raw))
+    await stream.initialize_discovery()
     max_retry = 10
     retry = 0
     while True:
@@ -240,7 +240,7 @@ def gather_data_invalid_auth():
         ),
     ],
 )
-async def test_gather_data(
+async def test_gather_discovery_data(
     status,
     response_gen,
     expected_messages,
@@ -259,21 +259,21 @@ async def test_gather_data(
     if response_gen:
         mocker.patch.object(
             bridge,
-            "fetch_data",
+            "fetch_discovery_data",
             side_effect=response_gen(),
         )
     else:
         mocker.patch.object(
             bridge,
-            "fetch_data",
+            "fetch_discovery_data",
             side_effect=expected_error,
         )
     emit_calls = mocker.patch.object(stream, "emit")
     if response_gen:
-        await stream.gather_data()
+        await stream.gather_discovery_data()
     else:
         with pytest.raises(expected_error.__class__):
-            await stream.gather_data()
+            await stream.gather_discovery_data()
     assert emit_calls.call_count == len(expected_emits)
     for index, emit in enumerate(expected_emits):
         assert emit_calls.call_args_list[index][0][0] == emit, f"Issue at index {index}"
@@ -460,7 +460,7 @@ async def test_generate_events_from_data_multi(bridge):
         (None, None, KeyError, [], []),
     ],
 )
-async def test_perform_poll(
+async def test_perform_discovery_poll(
     gather_data_return,
     gather_data_side_effect,
     generate_events_from_data_side_effect,
@@ -472,10 +472,10 @@ async def test_perform_poll(
     stream = bridge.events
     await stream.stop()
     if gather_data_side_effect:
-        mocker.patch.object(stream, "gather_data", side_effect=gather_data_side_effect)
+        mocker.patch.object(stream, "gather_discovery_data", side_effect=gather_data_side_effect)
     else:
         mocker.patch.object(
-            stream, "gather_data", AsyncMock(return_value=gather_data_return)
+            stream, "gather_discovery_data", AsyncMock(return_value=gather_data_return)
         )
     if generate_events_from_data_side_effect:
         mocker.patch.object(
@@ -489,7 +489,7 @@ async def test_perform_poll(
         "doesnt_exist_list": bridge.lights,
     }
     emit_calls = mocker.patch.object(stream, "emit")
-    await stream.perform_poll()
+    await stream.perform_discovery_poll()
     await stream._bridge.async_block_until_done()
     assert emit_calls.call_count == len(expected_emits)
     for index, emit in enumerate(expected_emits):
@@ -506,7 +506,7 @@ async def test_perform_poll(
 
 
 @pytest.mark.asyncio
-async def test_event_reader_dev_update(bridge, mocker):
+async def test_event_discovery_dev_update(bridge, mocker):
     stream = bridge.events
     bridge.lights.initialize()
     await bridge.lights.initialize_elem(a21_light)
@@ -515,10 +515,10 @@ async def test_event_reader_dev_update(bridge, mocker):
 
     mocker.patch.object(
         stream,
-        "gather_data",
+        "gather_discovery_data",
         AsyncMock(return_value=utils.create_hs_raw_from_dump("light-a21.json")),
     )
-    await stream.initialize_reader()
+    await stream.initialize_discovery()
     max_retry = 10
     retry = 0
     while True:
@@ -546,7 +546,7 @@ async def test_event_reader_dev_update(bridge, mocker):
 
 
 @pytest.mark.asyncio
-async def test_event_reader_dev_delete(bridge, mocker):
+async def test_event_discovery_dev_delete(bridge, mocker):
     stream = bridge.events
     bridge.lights.initialize()
     bridge.lights.initialize_elem(a21_light)
@@ -556,9 +556,9 @@ async def test_event_reader_dev_delete(bridge, mocker):
     def afero_dev(dev):
         return dev
 
-    mocker.patch.object(bridge, "fetch_data", AsyncMock(return_value=[]))
+    mocker.patch.object(bridge, "fetch_discovery_data", AsyncMock(return_value=[]))
     mocker.patch.object(event, "get_afero_device", side_effect=afero_dev)
-    await stream.initialize_reader()
+    await stream.initialize_discovery()
     max_retry = 10
     retry = 0
     while True:

--- a/tests/v1/controllers/test_event.py
+++ b/tests/v1/controllers/test_event.py
@@ -27,7 +27,7 @@ switch = utils.create_devices_from_data("switch-HPDA311CWB.json")[0]
 @pytest.mark.asyncio
 async def test_properties(bridge):
     stream = bridge.events
-    assert len(stream._scheduled_tasks) == 2
+    assert len(stream._scheduled_tasks) == 3
     stream._status = event.EventStreamStatus.CONNECTING
     assert stream.connected is False
     assert stream.status == event.EventStreamStatus.CONNECTING
@@ -57,9 +57,9 @@ async def test_properties(bridge):
 @pytest.mark.asyncio
 async def test_initialize(bridge):
     stream = bridge.events
-    assert len(stream._scheduled_tasks) == 2
+    assert len(stream._scheduled_tasks) == 3
     await stream.initialize()
-    assert len(stream._scheduled_tasks) == 2
+    assert len(stream._scheduled_tasks) == 3
 
 
 @pytest.mark.asyncio
@@ -747,3 +747,101 @@ async def test_wait_for_first_poll(bridge):
     stream._first_poll_completed = True
     await asyncio.sleep(0.1)
     assert task.done() is True
+
+
+@pytest.mark.asyncio
+async def test_device_polling(bridge, mocker):
+    stream = bridge.events
+    await stream.stop()
+    stream._first_poll_completed = True
+    stream._polling_interval = 0.01
+
+    dev = mocker.Mock(spec=event.AferoDevice)
+    dev.id = "dev1"
+    mocker.patch.object(
+        bridge, "fetch_all_device_states", AsyncMock(return_value=[dev])
+    )
+    mocker.patch.object(stream, "split_devices", AsyncMock(return_value=[dev]))
+
+    task = asyncio.create_task(stream._EventStream__device_polling())
+    event_obj = await stream._event_queue.get()
+    assert event_obj["type"] == event.EventType.RESOURCE_UPDATE_RESPONSE
+    assert event_obj["device_id"] == "dev1"
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_device_polling_exception(bridge, mocker, caplog):
+    stream = bridge.events
+    await stream.stop()
+    stream._first_poll_completed = True
+    stream._polling_interval = 0.01
+
+    mocker.patch.object(
+        bridge, "fetch_all_device_states", side_effect=Exception("Polling failed")
+    )
+
+    task = asyncio.create_task(stream._EventStream__device_polling())
+    await asyncio.sleep(0.05)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    assert "Unable to poll device states" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_emit_resource_filter_edge_cases(bridge, mocker):
+    stream = bridge.events
+    await stream.stop()
+    callback = mocker.Mock()
+    stream.subscribe(callback, resource_filter=(ResourceTypes.LIGHT.value,))
+
+    # Case 1: data is None
+    stream.emit(event.EventType.RESOURCE_UPDATED, None)
+    callback.assert_called_once()
+    callback.reset_mock()
+
+    # Case 2: data has no 'device' key
+    stream.emit(event.EventType.RESOURCE_UPDATED, {"type": event.EventType.RESOURCE_UPDATED})
+    callback.assert_called_once()
+    callback.reset_mock()
+
+    # Case 3: device has no device_class attribute
+    class Dummy:
+        pass
+
+    event_to_emit = event.AferoEvent(
+        type=event.EventType.RESOURCE_UPDATED,
+        device_id="cool_id",
+        device=Dummy(),
+    )
+    stream.emit(event.EventType.RESOURCE_UPDATED, event_to_emit)
+    callback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_device_polling_not_ready(bridge, mocker):
+    """Test that device polling is skipped if the first poll is not complete."""
+    stream = bridge.events
+    await stream.stop()
+    stream._first_poll_completed = False
+    stream._polling_interval = 0.01
+
+    mock_fetch = mocker.patch.object(
+        bridge, "fetch_all_device_states", new_callable=AsyncMock
+    )
+
+    task = asyncio.create_task(stream._EventStream__device_polling())
+    await asyncio.sleep(0.05)  # Let it run for a few cycles to ensure it continues
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    mock_fetch.assert_not_called()

--- a/tests/v1/controllers/test_event.py
+++ b/tests/v1/controllers/test_event.py
@@ -771,7 +771,7 @@ async def test_device_polling(bridge, mocker):
     try:
         await task
     except asyncio.CancelledError:
-        pass
+        pass  # Expected cancellation, ignore
 
 
 @pytest.mark.asyncio
@@ -791,7 +791,7 @@ async def test_device_polling_exception(bridge, mocker, caplog):
     try:
         await task
     except asyncio.CancelledError:
-        pass
+        pass  # Expected cancellation, ignore
     assert "Unable to poll device states" in caplog.text
 
 

--- a/tests/v1/controllers/test_security_system_sensor.py
+++ b/tests/v1/controllers/test_security_system_sensor.py
@@ -203,9 +203,9 @@ async def test_update_security_sensor_no_updates(mocked_controller):
                     "functionClass": "sensor-config",
                     "value": {
                         "security-sensor-config-v2": {
-                            "chirpMode": 1,
-                            "triggerType": 3,
-                            "bypassType": 4,
+                            "chirpMode": 1,  # On
+                            "triggerType": 2,  # Away
+                            "bypassType": 4,  # On
                         }
                     },
                     "functionInstance": "sensor-2",
@@ -237,7 +237,7 @@ async def test_set_state(device, updates, expected_updates, mocked_controller, m
     await bridge.async_block_until_done()
     dev = mocked_controller["7f4e4c01-e799-45c5-9b1a-385433a78edc-sensor-2"]
     assert dev.selects[("chirpMode", None)].selected == 'On'
-    assert dev.selects[("triggerType", None)].selected == 'Home/Away'
+    assert dev.selects[("triggerType", None)].selected == 'Away'
     assert dev.selects[("bypassType", None)].selected == 'On'
 
 

--- a/tests/v1/test___init__.py
+++ b/tests/v1/test___init__.py
@@ -538,3 +538,40 @@ async def test_adjust_temperature_unit(start_unit, new_unit, called, mocked_brid
     await mocked_bridge.adjust_temperature_unit(new_unit)
     assert mocked_bridge.temperature_unit == new_unit
     assert mocked_bridge.add_job.called == called
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_device_states(mocked_bridge, mocker, caplog):
+    dev1 = mocker.Mock(spec=AferoDevice)
+    dev1.id = "dev1"
+    dev2 = mocker.Mock(spec=AferoDevice)
+    dev2.id = "dev2"
+    mocked_bridge._known_devs = {
+        "dev1": mocker.Mock(),
+        "dev2": mocker.Mock(),
+        "dev3": mocker.Mock(),
+        "dev4": mocker.Mock(),
+    }
+    mocked_bridge._known_afero_devices = {"dev1": dev1, "dev2": dev2}
+
+    states1 = [AferoState(functionClass="power", value="on")]
+    states2 = [AferoState(functionClass="brightness", value=50)]
+    states4 = [AferoState(functionClass="color", value="blue")]
+
+    async def side_effect(device_id):
+        if device_id == "dev1":
+            return "dev1", states1
+        if device_id == "dev2":
+            return "dev2", states2
+        if device_id == "dev3":
+            raise Exception("Boom")
+        if device_id == "dev4":
+            return "dev4", states4
+
+    mocker.patch.object(mocked_bridge, "_fetch_device_states", side_effect=side_effect)
+    updated_devices = await mocked_bridge.fetch_all_device_states()
+    assert len(updated_devices) == 2
+    assert dev1.states == states1
+    assert dev2.states == states2
+    assert "Unable to fetch states: Boom" in caplog.text
+    assert "Device dev4 not found in cache" in caplog.text

--- a/tests/v1/test___init__.py
+++ b/tests/v1/test___init__.py
@@ -133,7 +133,7 @@ async def test_initialize(bridge_with_acct, mocker):
         ("i dont know", True, TemperatureUnit.CELSIUS),
     ],
 )
-async def test_fetch_data(expected_val, error, temperature_unit, mocked_bridge_req, mocker):
+async def test_fetch_discovery_data(expected_val, error, temperature_unit, mocked_bridge_req, mocker):
     expected = mocker.Mock()
     mocked_bridge_req.temperature_unit = temperature_unit
     mocker.patch.object(
@@ -141,7 +141,7 @@ async def test_fetch_data(expected_val, error, temperature_unit, mocked_bridge_r
     )
     mocker.patch.object(mocked_bridge_req, "request", return_value=expected)
     if not error:
-        assert await mocked_bridge_req.fetch_data() == expected_val
+        assert await mocked_bridge_req.fetch_discovery_data() == expected_val
         call = mocked_bridge_req.request.call_args
         params = call[1]["params"]
         if temperature_unit == TemperatureUnit.FAHRENHEIT:
@@ -151,7 +151,7 @@ async def test_fetch_data(expected_val, error, temperature_unit, mocked_bridge_r
             assert "units" not in params
     else:
         with pytest.raises(TypeError):
-            await mocked_bridge_req.fetch_data()
+            await mocked_bridge_req.fetch_discovery_data()
 
 
 def fake_version_data(*args, **kwargs):
@@ -160,7 +160,7 @@ def fake_version_data(*args, **kwargs):
 
 
 @pytest.mark.asyncio
-async def test_fetch_data_with_version(mocked_bridge_req, mocker):
+async def test_fetch_discovery_data_with_version(mocked_bridge_req, mocker):
     get_device_versions = mocker.patch.object(mocked_bridge_req, "get_device_version", side_effect=fake_version_data())
     mocked_response = [
         {
@@ -184,7 +184,7 @@ async def test_fetch_data_with_version(mocked_bridge_req, mocker):
         expected, "json", side_effect=mocker.AsyncMock(return_value=mocked_response)
     )
     mocker.patch.object(mocked_bridge_req, "request", return_value=expected)
-    resp = await mocked_bridge_req.fetch_data(version_poll=True)
+    resp = await mocked_bridge_req.fetch_discovery_data(version_poll=True)
     assert get_device_versions.call_count == 2
     assert get_device_versions.call_args_list[0][0][0] == "test_device_id"
     assert get_device_versions.call_args_list[1][0][0] == "test_device_id2"


### PR DESCRIPTION
Update how polling is performed so a discovery poll isnt performed for normal data collection. This has reduced the total bandwidth for polling by approximately 91%.


```python

# Populate the devices for the single-go test
await bridge.initialize()

# Current polling method
params = {"expansions": "state,capabilities,semantics"}
url = bridge.generate_api_url(v1.v1_const.AFERO_GENERICS["API_DEVICE_ENDPOINT"].format(bridge.account_id))
res = await bridge.request("get", url, headers=headers, params=params)
data = await res.json()
len(str(data))
# Full query (string length): 129863

# State-only polling method
params = {"expansions": "state"}
url = bridge.generate_api_url(v1.v1_const.AFERO_GENERICS["API_DEVICE_ENDPOINT"].format(bridge.account_id))
res = await bridge.request("get", url, headers=headers, params=params)
data = await res.json()
len(str(data))
# I reviewed the data and this still includes function data which adds a lot of overhead
# Partial query (string length): 99766
# ~23% reduction in size


# One call per device:
url = bridge.generate_api_url(v1.v1_const.AFERO_GENERICS["API_DEVICE_STATE_ENDPOINT"].format(bridge.account_id, data[2]["id"]))
res = await bridge.request("get", url, headers=headers)
data = await res.json()
len(str(data))
# Device only (string length): 1472

# Make all queries in a single go
urls = [bridge.generate_api_url(v1.v1_const.AFERO_GENERICS["API_DEVICE_STATE_ENDPOINT"].format(bridge.account_id, dev_id)) for dev_id in bridge._known_devs.keys()]
results = await asyncio.gather(*(bridge.request("get", url, headers=headers) for url in urls))
total_len = sum([len(str((await res.json()))) for res in results])
# Total length of results: 12312
# ~91% reduction in size
```