### PR TITLE
Fix functionInstance for split light updates and test session cleanup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ MANIFEST
 
 
 .ruff_cache
+uv.lock

--- a/src/aioafero/v1/controllers/base.py
+++ b/src/aioafero/v1/controllers/base.py
@@ -622,6 +622,8 @@ def get_afero_instance_for_state(
     """Determine the function instance based on the field data or device."""
     if hasattr(feature, "func_instance") and getattr(feature, "func_instance", None):
         instance = getattr(feature, "func_instance", None)
+    elif getattr(elem, "split_identifier", None) and getattr(elem, "instance", None):
+        instance = elem.instance
     elif (
         mapped_afero_key
         and hasattr(elem, "get_instance")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,10 @@ def reset_logging_secrets():
 
 @pytest_asyncio.fixture(scope="function")
 async def aio_sess() -> aiohttp.ClientSession:
-    yield aiohttp.ClientSession()
+    session = aiohttp.ClientSession()
+    yield session
+    if not session.closed:
+        await session.close()
 
 
 @pytest_asyncio.fixture
@@ -43,6 +46,7 @@ async def mocked_bridge(mocker, aio_sess) -> AferoBridgeV1:
     )
     mocker.patch.object(bridge.events, "_first_poll_completed", True)
     mocker.patch.object(bridge, "_web_session", aio_sess)
+    bridge._close_session = False
 
     bridge.set_token_data(
         TokenData(
@@ -114,6 +118,7 @@ def mocked_bridge_req(mocker, aio_sess):
     mocker.patch.object(bridge, "fetch_discovery_data", side_effect=bridge.fetch_discovery_data)
     mocker.patch.object(bridge, "request", side_effect=bridge.request)
     mocker.patch.object(bridge, "_web_session", aio_sess)
+    bridge._close_session = False
     mocker.patch.object(bridge.events, "_first_poll_completed", True)
     bridge._auth._token_data = TokenData(
         "mock-token",
@@ -182,6 +187,7 @@ async def bridge_with_acct(mocker):
             expiration=datetime.datetime.now().timestamp() + 200,
         )
     yield bridge
+    await bridge.close()
 
 
 @pytest_asyncio.fixture

--- a/tests/v1/controllers/test_base.py
+++ b/tests/v1/controllers/test_base.py
@@ -19,7 +19,8 @@ from aioafero.v1.controllers.base import (
     get_afero_states_from_list,
     get_afero_states_from_mapped,
 )
-from aioafero.v1.models.features import SelectFeature
+from aioafero.v1.models.features import ColorFeature, SelectFeature
+from aioafero.v1.models.light import Light
 from aioafero.v1.models.resource import DeviceInformation
 import pytest_asyncio
 
@@ -117,6 +118,18 @@ test_res_funcs = TestResourceWithFunctions(
         "bean2": TestFeatureInstance(on=False, func_instance="bean2"),
     },
     device_information=DeviceInformation(),
+)
+
+split_light = Light(
+    _id="parent-id-light-trim",
+    available=True,
+    split_identifier="light",
+    device_information=DeviceInformation(
+        functions=[
+            {"functionClass": "color-rgb", "functionInstance": "trim"},
+            {"functionClass": "color-rgb", "functionInstance": "main"},
+        ]
+    ),
 )
 
 
@@ -1510,6 +1523,13 @@ def test_get_afero_states_from_mapped(
         (test_res, TestFeatureInstance(on=True, func_instance="bean1"), None, "bean1"),
         # Utilize instances
         (test_res_funcs, TestFeatureBool(on=True), "on", "super-beans"),
+        # Split devices use instance from entity id, not get_instance()
+        (
+            split_light,
+            ColorFeature(red=1, green=2, blue=3),
+            "color-rgb",
+            "trim",
+        ),
         # None fallback
         (test_res_funcs, TestFeatureBool(on=True), None, None),
     ],

--- a/tests/v1/controllers/test_light.py
+++ b/tests/v1/controllers/test_light.py
@@ -701,6 +701,68 @@ async def test_set_rgb(mocked_controller):
 
 
 @pytest.mark.asyncio
+async def test_set_rgb_trim(mocked_controller, mocker):
+    """Trim split lights must target the trim functionInstance, not main."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    trim_dev = mocked_controller[trim_light_trim_id]
+    trim_dev.on.on = False
+    trim_dev.color_mode.mode = "white"
+    trim_dev.color.red = 100
+    trim_dev.color.green = 100
+    trim_dev.color.blue = 100
+    resp = mocker.AsyncMock()
+    resp.status = 200
+    json_resp = mocker.AsyncMock()
+    json_resp.return_value = {"metadeviceId": trim_light.id, "values": []}
+    resp.json = json_resp
+    update_afero_api = mocker.patch.object(
+        mocked_controller, "update_afero_api", return_value=resp
+    )
+    await mocked_controller.set_rgb(trim_light_trim_id, 10, 20, 30)
+    await mocked_controller._bridge.async_block_until_done()
+    update_afero_api.assert_called_once()
+    assert update_afero_api.call_args[0][0] == trim_light.id
+    sent_states = update_afero_api.call_args[0][1]
+    instances = {
+        state["functionClass"]: state["functionInstance"] for state in sent_states
+    }
+    assert instances["power"] == "trim"
+    assert instances["color-rgb"] == "trim"
+    assert instances["color-mode"] == "trim"
+
+
+@pytest.mark.asyncio
+async def test_set_brightness_trim(mocked_controller, mocker):
+    """Trim split brightness updates must target the trim functionInstance."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    trim_dev = mocked_controller[trim_light_trim_id]
+    trim_dev.on.on = False
+    resp = mocker.AsyncMock()
+    resp.status = 200
+    json_resp = mocker.AsyncMock()
+    json_resp.return_value = {"metadeviceId": trim_light.id, "values": []}
+    resp.json = json_resp
+    update_afero_api = mocker.patch.object(
+        mocked_controller, "update_afero_api", return_value=resp
+    )
+    await mocked_controller.set_brightness(trim_light_trim_id, 42)
+    await mocked_controller._bridge.async_block_until_done()
+    update_afero_api.assert_called_once()
+    sent_states = update_afero_api.call_args[0][1]
+    instances = {
+        state["functionClass"]: state["functionInstance"] for state in sent_states
+    }
+    assert instances["power"] == "trim"
+    assert instances["brightness"] == "trim"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "effect",
     [

--- a/tests/v1/test___init__.py
+++ b/tests/v1/test___init__.py
@@ -404,18 +404,21 @@ class AsyncContextManagerMock:
 async def test_request(max_retries, times_to_sleep, response_gen, exp_error, mocker):
     bridge = AferoBridgeV1("username", "password")
     mock_sleep = mocker.patch("asyncio.sleep", new=mocker.AsyncMock())
-    if response_gen:
-        async_mock_response = AsyncContextManagerMock()
-        mocker.patch.object(bridge, "create_request", return_value=async_mock_response)
-    if max_retries is not None:
-        mocker.patch.object(v1_const, "MAX_RETRIES", max_retries)
-    if exp_error:
-        with pytest.raises(exp_error):
+    try:
+        if response_gen:
+            async_mock_response = AsyncContextManagerMock()
+            mocker.patch.object(bridge, "create_request", return_value=async_mock_response)
+        if max_retries is not None:
+            mocker.patch.object(v1_const, "MAX_RETRIES", max_retries)
+        if exp_error:
+            with pytest.raises(exp_error):
+                await bridge.request("fff", "fff")
+        else:
             await bridge.request("fff", "fff")
-    else:
-        await bridge.request("fff", "fff")
-    if times_to_sleep:
-        assert mock_sleep.call_count == times_to_sleep
+        if times_to_sleep:
+            assert mock_sleep.call_count == times_to_sleep
+    finally:
+        await bridge.close()
 
 
 def test_get_afero_device(mocked_bridge):

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ passenv =
     HOME
     SETUPTOOLS_*
 extras =
-    testing
+    test
 commands =
     pytest {posargs}
 allowlist_externals =


### PR DESCRIPTION
Split lights now target the correct instance (e.g. trim vs main) when setting color and brightness. Close aiohttp sessions in test fixtures, and align tox extras with the pyproject test optional dependency.