### PR TITLE
Fix split-light handling and parent state cache updates (7.0.2)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Changelog
 =========
 
+Version 7.0.2
+=============
+
+ * Fix split-light polling to query parent metadevice ids once instead of synthetic split ids
+ * Cache split light clones separately so parent state is not overwritten
+ * Ignore other instances' power states when applying inbound updates to split lights
+ * Merge partial API state responses into cached device state instead of replacing it
+ * Use instance-scoped `color_modes` on split lights so capability flags match each zone
+ * Route white-only control on white-only zones through `color-mode: white`
+ * Ignore inbound `color-temperature` updates for lights that have no CCT function
+
 Version 7.0.1
 =============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aioafero"
-version = "7.0.1"
+version = "7.0.2"
 dependencies = [
   "aiohttp",
   "beautifulsoup4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,17 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
+# Test-only deps; not installed by Home Assistant integrations.
 test = [
   "pytest",
   "pytest-mock",
   "pytest-cov",
   "pytest-asyncio",
+  # aioresponses 0.7.8 is incompatible with aiohttp 3.14+ (ClientResponse requires
+  # stream_writer). Runtime aiohttp stays unpinned so HA can use its bundled version;
+  # tests/conftest.py patches mocked responses until aioresponses ships the fix
+  # (https://github.com/pnuckowski/aioresponses/pull/288). Bump aioresponses and
+  # remove that shim once a release includes 3.14 support.
   "aioresponses",
   "pytest-aioresponses",
   "anyio[trio]",

--- a/src/aioafero/device.py
+++ b/src/aioafero/device.py
@@ -151,6 +151,16 @@ def convert_state(state: dict[str, Any]) -> AferoState:
     )
 
 
+def merge_afero_states(
+    existing: list[AferoState], incoming: list[AferoState]
+) -> list[AferoState]:
+    """Merge incoming states into existing by functionClass and functionInstance."""
+    merged = {(s.functionClass, s.functionInstance): s for s in existing}
+    for state in incoming:
+        merged[(state.functionClass, state.functionInstance)] = state
+    return list(merged.values())
+
+
 def get_afero_device(afero_device: dict[str, Any]) -> AferoDevice:
     """Convert the Afero device definition into a AferoDevice."""
     description = afero_device.get("description", {})

--- a/src/aioafero/v1/__init__.py
+++ b/src/aioafero/v1/__init__.py
@@ -261,6 +261,16 @@ class AferoBridgeV1:
         except KeyError as err:
             raise DeviceNotFound(f"Unable to find device for {device_id}") from err
 
+    def resolve_metadevice_id(self, device_id: str) -> str:
+        """Return the Afero API metadevice ID used for state queries and updates."""
+        try:
+            device = self.get_afero_device(device_id)
+        except DeviceNotFound:
+            return device_id
+        if device.split_identifier:
+            return device.id.rsplit(f"-{device.split_identifier}-", 1)[0]
+        return device_id
+
     @property
     def account_id(self) -> str:
         """Get the account ID for the Afero IoT account."""
@@ -456,9 +466,13 @@ class AferoBridgeV1:
 
     async def _fetch_all_device_states(self) -> list[AferoDevice]:
         """Query the API for all known device states."""
-        # known_devs keeps track of all devices, while .devices is only "parent" items
-        device_ids = list(self._known_devs.keys())
-        tasks = [self._fetch_device_states(dev_id) for dev_id in device_ids]
+        # Split entities share a parent metadevice; poll each parent once.
+        metadevice_ids = {
+            self.resolve_metadevice_id(device_id) for device_id in self._known_devs
+        }
+        tasks = [
+            self._fetch_device_states(metadevice_id) for metadevice_id in metadevice_ids
+        ]
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
         updated_devices: list[AferoDevice] = []

--- a/src/aioafero/v1/controllers/base.py
+++ b/src/aioafero/v1/controllers/base.py
@@ -18,6 +18,7 @@ from aioafero.device import (
     AferoState,
     convert_state,
     get_afero_device,
+    merge_afero_states,
 )
 from aioafero.errors import DeviceNotFound, ExceededMaximumRetries
 from aioafero.types import TemperatureUnit
@@ -523,7 +524,10 @@ class BaseResourcesController(Generic[AferoResource]):
         if res := await self.update_afero_api(update_id, device_states):
             resp_json = await res.json()
             states = [convert_state(val) for val in resp_json.get("values", [])]
-            update_dev = self.generate_update_dev(resp_json["metadeviceId"], states)
+            # Always merge into the parent metadevice cache (update_id). Split clones
+            # are cached separately; response metadeviceId may match update_id on API
+            # responses but tests may echo the resource id instead.
+            update_dev = self.generate_update_dev(update_id, states)
             update_dev.id = update_id
             await self._bridge.events.generate_events_from_update(update_dev)
             return res
@@ -534,7 +538,7 @@ class BaseResourcesController(Generic[AferoResource]):
     ) -> AferoDevice:
         """Generate update data for the event controller."""
         afero_dev = self._bridge.get_afero_device(device_id)
-        afero_dev.states = states
+        afero_dev.states = merge_afero_states(afero_dev.states, states)
         return afero_dev
 
     def get_device(self, device_id) -> AferoResource:

--- a/src/aioafero/v1/controllers/event.py
+++ b/src/aioafero/v1/controllers/event.py
@@ -334,8 +334,11 @@ class EventStream:
                         "Found %s devices from %s", len(split_devs.split_devices), name
                     )
                     for split_dev in split_devs.split_devices:
-                        self._bridge.add_afero_dev(dev, split_dev.id)
-                        dev.children.append(split_dev.id)
+                        if split_dev.split_identifier:
+                            # Cache each split clone under its own id; parent stays at dev.id.
+                            self._bridge.add_afero_dev(split_dev)
+                        if split_dev.id != dev.id and split_dev.id not in dev.children:
+                            dev.children.append(split_dev.id)
                     devices.extend(split_devs.split_devices)
         self._logger.debug("Total number of devices (post split): %s", len(devices))
         return devices

--- a/src/aioafero/v1/controllers/light.py
+++ b/src/aioafero/v1/controllers/light.py
@@ -57,16 +57,29 @@ def get_split_instances(afero_dev: AferoDevice) -> list[tuple[str, ResourceTypes
     return sorted(instances)
 
 
+def state_belongs_to_light_instance(
+    afero_dev: AferoDevice, state: AferoState, instance: str
+) -> bool:
+    """Return whether a state belongs to a light zone instance."""
+    if state.functionClass == "available":
+        return True
+    if afero_dev.model == "LCN3002LM-01 WH":
+        if state.functionInstance == "primary":
+            return False
+        return (instance == "white" and state.functionInstance == instance) or (
+            instance != "white" and state.functionInstance != "white"
+        )
+    if state.functionInstance in (None, "global", "primary"):
+        return False
+    return state.functionInstance == instance
+
+
 def state_matches_instance(afero_device: AferoDevice, state: AferoState) -> bool:
     """Return whether a state belongs to a split light instance."""
     if not afero_device.split_identifier:
         return True
-    if state.functionClass == "available":
-        return True
-    if state.functionInstance in (None, "global", "primary"):
-        return False
     instance = afero_device.id.rsplit(f"-{afero_device.split_identifier}-", 1)[1]
-    return state.functionInstance == instance
+    return state_belongs_to_light_instance(afero_device, state, instance)
 
 
 def resolve_function_instance(afero_device: AferoDevice) -> str | None:
@@ -95,21 +108,11 @@ def get_color_modes_for_device(afero_device: AferoDevice) -> list[str]:
 
 def get_valid_states(afero_dev: AferoDevice, instance: str) -> list:
     """Find states associated with the specific instance."""
-    valid_states: list = []
-    for state in afero_dev.states:
-        if state.functionClass == "available":
-            valid_states.append(state)
-        # This light is unique where color uses instance "color" and None
-        elif afero_dev.model == "LCN3002LM-01 WH":
-            if state.functionInstance == "primary":
-                continue
-            if (instance == "white" and state.functionInstance == instance) or (
-                instance != "white" and state.functionInstance != "white"
-            ):
-                valid_states.append(state)
-        elif state.functionInstance == instance:
-            valid_states.append(state)
-    return valid_states
+    return [
+        state
+        for state in afero_dev.states
+        if state_belongs_to_light_instance(afero_dev, state, instance)
+    ]
 
 
 def light_callback(afero_device: AferoDevice) -> CallbackResponse:

--- a/src/aioafero/v1/controllers/light.py
+++ b/src/aioafero/v1/controllers/light.py
@@ -57,6 +57,42 @@ def get_split_instances(afero_dev: AferoDevice) -> list[tuple[str, ResourceTypes
     return sorted(instances)
 
 
+def state_matches_instance(afero_device: AferoDevice, state: AferoState) -> bool:
+    """Return whether a state belongs to a split light instance."""
+    if not afero_device.split_identifier:
+        return True
+    if state.functionClass == "available":
+        return True
+    if state.functionInstance in (None, "global", "primary"):
+        return False
+    instance = afero_device.id.rsplit(f"-{afero_device.split_identifier}-", 1)[1]
+    return state.functionInstance == instance
+
+
+def resolve_function_instance(afero_device: AferoDevice) -> str | None:
+    """Return the functionInstance key for this light resource (split zone or single)."""
+    if afero_device.split_identifier:
+        return afero_device.id.rsplit(f"-{afero_device.split_identifier}-", 1)[1]
+    for state in afero_device.states:
+        if state.functionClass == "color-mode":
+            return state.functionInstance
+    return None
+
+
+def get_color_modes_for_device(afero_device: AferoDevice) -> list[str]:
+    """Return supported color-mode names for this zone's color-mode function."""
+    instance = resolve_function_instance(afero_device)
+    for function in afero_device.functions:
+        if function.get("functionClass") != "color-mode":
+            continue
+        if function.get("functionInstance") == instance:
+            return [value["name"] for value in function.get("values", [])]
+    for function in afero_device.functions:
+        if function.get("functionClass") == "color-mode":
+            return [value["name"] for value in function.get("values", [])]
+    return []
+
+
 def get_valid_states(afero_dev: AferoDevice, instance: str) -> list:
     """Find states associated with the specific instance."""
     valid_states: list = []
@@ -84,8 +120,8 @@ def light_callback(afero_device: AferoDevice) -> CallbackResponse:
     instances = get_split_instances(afero_device)
     logger.debug("Light instances found: %s", instances)
     light_instances = [x[0] for x in instances if x[1] == ResourceTypes.LIGHT]
+    children: list[str] = []
     if afero_device.device_class == ResourceTypes.LIGHT.value:
-        children = []
         for instance, resource_type in instances:
             instance_name = instance if instance else "primary"
             cloned = copy.deepcopy(afero_device)
@@ -154,9 +190,38 @@ class LightController(BaseResourcesController[Light]):
         await self.set_state(device_id, on=False)
 
     async def set_color_temperature(self, device_id: str, temperature: int) -> None:
-        """Set Color Temperature to light. Turn on light if it's currently off."""
+        """Set color temperature, or white mode when the zone has no CCT function."""
+        try:
+            cur_item = self.get_device(device_id)
+        except errors.DeviceNotFound:
+            self._logger.info("Unable to find device %s", device_id)
+            return
+        if cur_item.color_temperature is not None:
+            await self.set_state(
+                device_id, on=True, temperature=temperature, color_mode="white"
+            )
+        elif cur_item.supports_color_white:
+            self._logger.info(
+                "Device %s has no color-temperature function; ignoring %d K",
+                device_id,
+                temperature,
+            )
+            await self.set_white(device_id, on=True)
+        else:
+            self._logger.info(
+                "Device %s does not support color temperature or white mode", device_id
+            )
+
+    async def set_white(
+        self,
+        device_id: str,
+        *,
+        on: bool | None = True,
+        brightness: int | None = None,
+    ) -> None:
+        """Set API white mode (color-mode white) without a color-temperature function."""
         await self.set_state(
-            device_id, on=True, temperature=temperature, color_mode="white"
+            device_id, on=on, color_mode="white", brightness=brightness
         )
 
     async def set_brightness(self, device_id: str, brightness: int) -> None:
@@ -236,15 +301,7 @@ class LightController(BaseResourcesController[Light]):
             if number := await self.initialize_number(func_def, state):
                 numbers[number[0]] = number[1]
 
-        supported_color_modes: list[str] = []
-        for function in afero_device.functions:
-            if function["functionClass"] != "color-mode":
-                continue
-            supported_color_modes = [
-                supported_color_mode["name"]
-                for supported_color_mode in function["values"]
-            ]
-            break
+        supported_color_modes = get_color_modes_for_device(afero_device)
 
         self._items[afero_device.id] = Light(
             _id=afero_device.id,
@@ -285,6 +342,9 @@ class LightController(BaseResourcesController[Light]):
         updated_keys = set()
         color_seq_states: dict[str, AferoState] = {}
         for state in afero_device.states:
+            # Split clones are pre-filtered in light_callback; this guards other paths.
+            if not state_matches_instance(afero_device, state):
+                continue
             if state.functionClass == "power" or (
                 afero_device.split_identifier and state.functionClass == "toggle"
             ):
@@ -293,6 +353,8 @@ class LightController(BaseResourcesController[Light]):
                     cur_item.on.on = new_val
                     updated_keys.add("on")
             elif state.functionClass == "color-temperature":
+                if cur_item.color_temperature is None:
+                    continue
                 current_temp = state.value
                 if isinstance(current_temp, str) and current_temp.endswith("K"):
                     current_temp = current_temp[:-1]
@@ -414,6 +476,11 @@ class LightController(BaseResourcesController[Light]):
                     supported=cur_item.color_temperature.supported,
                     prefix=cur_item.color_temperature.prefix,
                 )
+                if color_mode is None:
+                    color_mode = "white"
+            elif temperature is not None and cur_item.supports_color_white:
+                if color_mode is None:
+                    color_mode = "white"
             if brightness is not None and cur_item.dimming is not None:
                 update_obj.dimming = features.DimmingFeature(
                     brightness=brightness, supported=cur_item.dimming.supported
@@ -424,6 +491,13 @@ class LightController(BaseResourcesController[Light]):
                 )
             if color_mode is not None and cur_item.color_mode is not None:
                 update_obj.color_mode = features.ColorModeFeature(mode=color_mode)
+                if (
+                    color_mode == "white"
+                    and cur_item.color_temperature is None
+                    and cur_item.supports_color_white
+                    and cur_item.color_mode.mode != "white"
+                ):
+                    send_duplicate_states = True
             if effect is not None and cur_item.effect is not None:
                 update_obj.effect = features.EffectFeature(
                     effect=effect, effects=cur_item.effect.effects

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import datetime
 import asyncio
+import inspect
+from unittest.mock import Mock
 
 from aioresponses import aioresponses
 import pytest
@@ -13,6 +15,31 @@ from aioafero.v1.controllers.event import EventType
 from tests.v1.utils import create_hs_raw_from_device
 from aioafero.v1.controllers.base import BaseResourcesController, dataclass_to_afero
 import securelogging
+
+
+def _patch_aioresponses_for_aiohttp_314() -> None:
+    """Default stream_writer for mocked ClientResponse on aiohttp 3.14+.
+
+    aioresponses 0.7.8 constructs ClientResponse without the stream_writer
+    argument that aiohttp 3.14 made required. Remove once aioresponses ships
+    the fix (see pnuckowski/aioresponses#288).
+    """
+    if "stream_writer" not in inspect.signature(aiohttp.ClientResponse.__init__).parameters:
+        return
+    if getattr(aiohttp.ClientResponse.__init__, "_aioafero_aiohttp314_patch", False):
+        return
+    original_init = aiohttp.ClientResponse.__init__
+
+    def client_response_init(self, method, url, **kwargs):
+        if "stream_writer" not in kwargs:
+            kwargs["stream_writer"] = Mock(output_size=0)
+        return original_init(self, method, url, **kwargs)
+
+    client_response_init._aioafero_aiohttp314_patch = True  # type: ignore[attr-defined]
+    aiohttp.ClientResponse.__init__ = client_response_init  # type: ignore[method-assign]
+
+
+_patch_aioresponses_for_aiohttp_314()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -4,6 +4,7 @@ import os
 import pytest
 
 from aioafero import device
+from aioafero.device import AferoState, merge_afero_states
 from pathlib import Path
 
 current_path = os.path.dirname(os.path.realpath(__file__))
@@ -485,3 +486,16 @@ def test_capability_raw_dump():
             "step": 1
         }
     }
+
+
+def test_merge_afero_states():
+    existing = [
+        AferoState(functionClass="power", value="on", functionInstance="main"),
+        AferoState(functionClass="power", value="off", functionInstance="trim"),
+    ]
+    incoming = [
+        AferoState(functionClass="power", value="off", functionInstance="main"),
+    ]
+    merged = merge_afero_states(existing, incoming)
+    by_instance = {(s.functionInstance, s.value) for s in merged}
+    assert by_instance == {("main", "off"), ("trim", "off")}

--- a/tests/v1/controllers/test_light.py
+++ b/tests/v1/controllers/test_light.py
@@ -1,12 +1,16 @@
 """Test LightController"""
 
+from unittest.mock import AsyncMock
+
 import pytest
 from dataclasses import asdict
 
-from aioafero.device import AferoState
+from aioafero.device import AferoDevice, AferoState, merge_afero_states
 from aioafero.v1.controllers import event, light
+from aioafero.v1.controllers.base import get_afero_instance_for_state
 from aioafero.v1.controllers.light import LightController, features, process_color_temps
-from aioafero.v1.models.features import EffectFeature
+from aioafero.v1.controllers.light import state_matches_instance
+from aioafero.v1.models.features import ColorFeature, EffectFeature
 from aioafero.v1.models.light import Light
 from aioafero.v1.models.resource import ResourceTypes, DeviceInformation
 
@@ -26,6 +30,75 @@ speaker_power_light_speaker_id = f"{speaker_power_light.id}-light-speaker-power"
 trim_light = utils.create_devices_from_data("light-with-trim.json")[0]
 trim_light_primary_id = f"{trim_light.id}-light-main"
 trim_light_trim_id = f"{trim_light.id}-light-trim"
+
+
+def _trim_update_with_states(
+    trim_dev: Light,
+    *,
+    main_power: str | None = None,
+    main_brightness: int | None = None,
+    main_color_rgb: dict | None = None,
+    main_color_mode: str | None = None,
+    main_color_temperature: int | None = None,
+) -> AferoDevice:
+    """Build an inbound AferoDevice update containing only main-zone states."""
+    states: list[AferoState] = []
+    if main_power is not None:
+        states.append(
+            AferoState(
+                functionClass="power",
+                value=main_power,
+                lastUpdateTime=0,
+                functionInstance="main",
+            )
+        )
+    if main_brightness is not None:
+        states.append(
+            AferoState(
+                functionClass="brightness",
+                value=main_brightness,
+                lastUpdateTime=0,
+                functionInstance="main",
+            )
+        )
+    if main_color_rgb is not None:
+        states.append(
+            AferoState(
+                functionClass="color-rgb",
+                value=main_color_rgb,
+                lastUpdateTime=0,
+                functionInstance="main",
+            )
+        )
+    if main_color_mode is not None:
+        states.append(
+            AferoState(
+                functionClass="color-mode",
+                value=main_color_mode,
+                lastUpdateTime=0,
+                functionInstance="main",
+            )
+        )
+    if main_color_temperature is not None:
+        states.append(
+            AferoState(
+                functionClass="color-temperature",
+                value=main_color_temperature,
+                lastUpdateTime=0,
+                functionInstance="main",
+            )
+        )
+    return AferoDevice(
+        id=trim_dev.id,
+        device_id=trim_light.device_id,
+        model=trim_light.model,
+        device_class=ResourceTypes.LIGHT.value,
+        default_name=trim_light.default_name,
+        default_image=trim_light.default_image,
+        friendly_name=trim_dev.device_information.name,
+        split_identifier="light",
+        states=states,
+    )
 
 
 @pytest.fixture
@@ -335,6 +408,223 @@ def test_light_trim_callback():
     assert multi_devs[2].device_class == "parent-device"
 
 
+@pytest.mark.parametrize(
+    "state, expected",
+    [
+        (
+            AferoState(
+                functionClass="power",
+                value="on",
+                lastUpdateTime=0,
+                functionInstance="trim",
+            ),
+            True,
+        ),
+        (
+            AferoState(
+                functionClass="power",
+                value="off",
+                lastUpdateTime=0,
+                functionInstance="main",
+            ),
+            False,
+        ),
+        (
+            AferoState(
+                functionClass="power",
+                value="on",
+                lastUpdateTime=0,
+                functionInstance="global",
+            ),
+            False,
+        ),
+        (
+            AferoState(
+                functionClass="available",
+                value=True,
+                lastUpdateTime=0,
+                functionInstance=None,
+            ),
+            True,
+        ),
+    ],
+)
+def test_state_matches_instance_trim_zone(state, expected):
+    """Inbound split updates must ignore other zones and global controls."""
+    trim_device = AferoDevice(
+        id=trim_light_trim_id,
+        device_id=trim_light.device_id,
+        model=trim_light.model,
+        device_class="light",
+        default_name=trim_light.default_name,
+        default_image=trim_light.default_image,
+        friendly_name="trim",
+        split_identifier="light",
+    )
+    assert state_matches_instance(trim_device, state) is expected
+
+
+@pytest.mark.asyncio
+async def test_parent_cache_keeps_full_states_after_trim_split(mocked_bridge):
+    """Parent metadevice cache must stay the full device, not the parent-device shell."""
+    await mocked_bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_bridge.async_block_until_done()
+    parent = mocked_bridge.get_afero_device(trim_light.id)
+    assert parent.device_class == "light"
+    assert any(
+        s.functionClass == "power" and s.functionInstance == "main" for s in parent.states
+    )
+    assert any(
+        s.functionClass == "power" and s.functionInstance == "trim" for s in parent.states
+    )
+
+
+@pytest.mark.asyncio
+async def test_split_children_exclude_parent_id_and_dedupe(mocked_bridge):
+    """Parent children list must not include the parent id and must not grow on re-split."""
+    await mocked_bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_bridge.async_block_until_done()
+    parent = mocked_bridge.get_afero_device(trim_light.id)
+    assert trim_light.id not in parent.children
+    assert trim_light_trim_id in parent.children
+    assert trim_light_primary_id in parent.children
+    children_after_first = list(parent.children)
+    await mocked_bridge.events.split_devices([parent])
+    assert parent.children == children_after_first
+
+
+@pytest.mark.asyncio
+async def test_split_devices_cache_split_clones(mocked_bridge):
+    """Split children must be cached as filtered clones, not the parent device."""
+    await mocked_bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_bridge.async_block_until_done()
+    trim_cached = mocked_bridge.get_afero_device(trim_light_trim_id)
+    assert trim_cached.split_identifier == "light"
+    assert trim_cached.id == trim_light_trim_id
+    assert all(
+        s.functionInstance in (None, "trim") or s.functionClass == "available"
+        for s in trim_cached.states
+        if s.functionClass
+        in ("power", "brightness", "color-rgb", "color-mode", "color-temperature")
+    )
+
+
+@pytest.mark.asyncio
+async def test_trim_split_initializes_without_color_temperature(mocked_controller):
+    """Trim zone has white/RGB in API but no trim color-temperature (Hubspace Kelvin UI gap)."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    trim_dev = mocked_controller[trim_light_trim_id]
+    main_dev = mocked_controller[trim_light_primary_id]
+    assert trim_dev.color_temperature is None
+    assert main_dev.color_temperature is not None
+    assert trim_dev.color_mode is not None
+    assert "white" in (trim_dev.color_modes or [])
+
+
+def test_get_color_modes_for_device_trim_vs_main():
+    """Each split zone uses its own color-mode function definition."""
+    trim_light = utils.create_devices_from_data("light-with-trim.json")[0]
+    # Build split-shaped devices like light_callback does
+    trim_afero = AferoDevice(
+        id=trim_light_trim_id,
+        device_id=trim_light.device_id,
+        model=trim_light.model,
+        device_class="light",
+        default_name=trim_light.default_name,
+        default_image=trim_light.default_image,
+        friendly_name="trim",
+        split_identifier="light",
+        states=light.get_valid_states(trim_light, "trim"),
+        functions=trim_light.functions,
+    )
+    main_afero = AferoDevice(
+        id=trim_light_primary_id,
+        device_id=trim_light.device_id,
+        model=trim_light.model,
+        device_class="light",
+        default_name=trim_light.default_name,
+        default_image=trim_light.default_image,
+        friendly_name="main",
+        split_identifier="light",
+        states=light.get_valid_states(trim_light, "main"),
+        functions=trim_light.functions,
+    )
+    trim_modes = light.get_color_modes_for_device(trim_afero)
+    main_modes = light.get_color_modes_for_device(main_afero)
+    assert trim_modes == ["sequence", "white", "color"]
+    assert main_modes == ["circadian-rhythm", "sequence", "white", "color"]
+    assert "circadian-rhythm" not in trim_modes
+
+
+@pytest.mark.asyncio
+async def test_get_afero_instance_for_trim_split_uses_elem_instance(mocked_controller):
+    """Outbound must use elem.instance; get_instance() alone would pick main."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    trim_resource = mocked_controller[trim_light_trim_id]
+    assert trim_resource.instance == "trim"
+    assert trim_resource.get_instance("color-rgb") == "main"
+    assert (
+        get_afero_instance_for_state(
+            trim_resource, ColorFeature(red=0, green=0, blue=0), "color-rgb"
+        )
+        == "trim"
+    )
+
+
+def test_merge_afero_states_preserves_other_instances():
+    """Partial API payloads must not drop other functionInstance rows."""
+    existing = [
+        AferoState(functionClass="power", value="on", functionInstance="main"),
+        AferoState(functionClass="power", value="off", functionInstance="trim"),
+    ]
+    incoming = [
+        AferoState(functionClass="power", value="off", functionInstance="main"),
+    ]
+    merged = merge_afero_states(existing, incoming)
+    by_key = {(s.functionClass, s.functionInstance): s.value for s in merged}
+    assert by_key[("power", "main")] == "off"
+    assert by_key[("power", "trim")] == "off"
+
+
+@pytest.mark.asyncio
+async def test_generate_update_dev_merges_partial_trim_states(mocked_controller):
+    """PUT response subsets must merge into the parent cache."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    parent = mocked_controller._bridge.get_afero_device(trim_light.id)
+    assert any(
+        s.functionClass == "power" and s.functionInstance == "trim" for s in parent.states
+    )
+    mocked_controller.generate_update_dev(
+        trim_light.id,
+        [
+            AferoState(
+                functionClass="power",
+                value="off",
+                lastUpdateTime=0,
+                functionInstance="main",
+            )
+        ],
+    )
+    assert any(
+        s.functionClass == "power" and s.functionInstance == "trim" for s in parent.states
+    )
+
+
 @pytest.mark.asyncio
 async def test_initialize_a21(mocked_controller):
     await mocked_controller.initialize_elem(a21_light)
@@ -627,6 +917,33 @@ async def test_set_color_temperature(mocked_controller):
 
 
 @pytest.mark.asyncio
+async def test_set_state_temperature_defaults_color_mode_white(
+    mocked_controller, mocker
+):
+    """CCT updates without an explicit color_mode must still send color-mode white."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        [utils.create_hs_raw_from_device(a21_light)]
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    dev = mocked_controller[a21_light.id]
+    dev.color_mode.mode = "color"
+    resp = mocker.AsyncMock()
+    resp.status = 200
+    json_resp = mocker.AsyncMock()
+    json_resp.return_value = {"metadeviceId": a21_light.id, "values": []}
+    resp.json = json_resp
+    update_afero_api = mocker.patch.object(
+        mocked_controller, "update_afero_api", return_value=resp
+    )
+    await mocked_controller.set_state(a21_light.id, on=True, temperature=3475)
+    await mocked_controller._bridge.async_block_until_done()
+    sent_states = update_afero_api.call_args[0][1]
+    by_class = {state["functionClass"]: state for state in sent_states}
+    assert by_class["color-mode"]["value"] == "white"
+    assert "color-temperature" in by_class
+
+
+@pytest.mark.asyncio
 async def test_set_brightness(mocked_controller):
     bridge = mocked_controller._bridge
     await bridge.events.generate_events_from_data(
@@ -760,6 +1077,370 @@ async def test_set_brightness_trim(mocked_controller, mocker):
     }
     assert instances["power"] == "trim"
     assert instances["brightness"] == "trim"
+
+
+@pytest.mark.asyncio
+async def test_update_elem_trim_ignores_main_power(mocked_controller):
+    """Inbound updates must not apply main-zone power to the trim entity."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    trim_dev = mocked_controller[trim_light_trim_id]
+    trim_dev.on.on = True
+    await mocked_controller.update_elem(_trim_update_with_states(trim_dev, main_power="off"))
+    assert trim_dev.on.on is True
+
+
+@pytest.mark.asyncio
+async def test_update_elem_trim_ignores_main_brightness(mocked_controller):
+    """Inbound main brightness must not change trim dimming."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    trim_dev = mocked_controller[trim_light_trim_id]
+    trim_brightness = trim_dev.dimming.brightness
+    await mocked_controller.update_elem(
+        _trim_update_with_states(
+            trim_dev,
+            main_brightness=10,
+        )
+    )
+    assert trim_dev.dimming.brightness == trim_brightness
+
+
+@pytest.mark.asyncio
+async def test_update_elem_trim_ignores_main_color(mocked_controller):
+    """Inbound main RGB must not change trim color."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    trim_dev = mocked_controller[trim_light_trim_id]
+    await mocked_controller.update_elem(
+        _trim_update_with_states(
+            trim_dev,
+            main_color_rgb={"color-rgb": {"r": 1, "g": 2, "b": 3}},
+        )
+    )
+    assert trim_dev.color.red != 1
+    assert trim_dev.color.green != 2
+    assert trim_dev.color.blue != 3
+
+
+@pytest.mark.asyncio
+async def test_update_elem_ignores_color_temperature_without_feature(mocked_controller):
+    """Inbound main CCT rows must not crash trim resources with no CCT capability."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    trim_dev = mocked_controller[trim_light_trim_id]
+    updates = await mocked_controller.update_elem(
+        _trim_update_with_states(
+            trim_dev,
+            main_color_temperature=3000,
+        )
+    )
+    assert trim_dev.color_temperature is None
+    assert "color_temperature" not in updates
+
+
+@pytest.mark.asyncio
+async def test_set_white_trim_sends_color_mode_not_cct(mocked_controller, mocker):
+    """White-only zones use color-mode white, never main's color-temperature."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    trim_dev = mocked_controller[trim_light_trim_id]
+    assert trim_dev.supports_color_white
+    trim_dev.color_mode.mode = "color"
+    resp = mocker.AsyncMock()
+    resp.status = 200
+    json_resp = mocker.AsyncMock()
+    json_resp.return_value = {"metadeviceId": trim_light.id, "values": []}
+    resp.json = json_resp
+    update_afero_api = mocker.patch.object(
+        mocked_controller, "update_afero_api", return_value=resp
+    )
+    await mocked_controller.set_white(trim_light_trim_id, on=None, brightness=40)
+    await mocked_controller._bridge.async_block_until_done()
+    update_afero_api.assert_called_once()
+    assert update_afero_api.call_args[0][0] == trim_light.id
+    sent_states = update_afero_api.call_args[0][1]
+    by_class = {state["functionClass"]: state for state in sent_states}
+    assert by_class["color-mode"]["functionInstance"] == "trim"
+    assert by_class["color-mode"]["value"] == "white"
+    assert by_class["brightness"]["functionInstance"] == "trim"
+    assert by_class["brightness"]["value"] == 40
+    assert "color-temperature" not in by_class
+
+
+@pytest.mark.asyncio
+async def test_set_color_temperature_trim_routes_to_white(mocked_controller, mocker):
+    """set_color_temperature on a white-only zone must not emit color-temperature."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    trim_dev = mocked_controller[trim_light_trim_id]
+    assert trim_dev.supports_color_white
+    assert trim_dev.color_temperature is None
+    trim_dev.color_mode.mode = "color"
+    resp = mocker.AsyncMock()
+    resp.status = 200
+    json_resp = mocker.AsyncMock()
+    json_resp.return_value = {"metadeviceId": trim_light.id, "values": []}
+    resp.json = json_resp
+    update_afero_api = mocker.patch.object(
+        mocked_controller, "update_afero_api", return_value=resp
+    )
+    await mocked_controller.set_color_temperature(trim_light_trim_id, 2700)
+    await mocked_controller._bridge.async_block_until_done()
+    update_afero_api.assert_called_once()
+    sent_states = update_afero_api.call_args[0][1]
+    by_class = {state["functionClass"]: state for state in sent_states}
+    assert by_class["color-mode"]["functionInstance"] == "trim"
+    assert by_class["color-mode"]["value"] == "white"
+    assert "color-temperature" not in by_class
+
+
+@pytest.mark.asyncio
+async def test_set_color_temperature_missing_device(mocked_controller, mocker):
+    """Unknown device id must not call the API."""
+    update_afero_api = mocker.patch.object(mocked_controller, "update_afero_api")
+    await mocked_controller.set_color_temperature("missing-light-id", 3000)
+    update_afero_api.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_color_temperature_no_cct_no_white(mocked_controller, mocker):
+    """Lights without CCT or white mode must not send updates."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    trim_dev = mocked_controller[trim_light_trim_id]
+    trim_dev.color_modes = ["color", "sequence"]
+    update_afero_api = mocker.patch.object(mocked_controller, "update_afero_api")
+    await mocked_controller.set_color_temperature(trim_light_trim_id, 2700)
+    update_afero_api.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_color_temperature_trim_logs_ignored_kelvin(
+    mocked_controller, mocker, caplog
+):
+    """White-only zones log that the requested Kelvin value is ignored."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    resp = mocker.AsyncMock()
+    resp.status = 200
+    json_resp = mocker.AsyncMock()
+    json_resp.return_value = {"metadeviceId": trim_light.id, "values": []}
+    resp.json = json_resp
+    mocker.patch.object(mocked_controller, "update_afero_api", return_value=resp)
+    caplog.set_level("INFO")
+    await mocked_controller.set_color_temperature(trim_light_trim_id, 2700)
+    assert "ignoring 2700 K" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_set_white_trim_already_white_omits_duplicate_color_mode(
+    mocked_controller, mocker
+):
+    """Brightness-only updates while already in API white need not re-send color-mode."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    trim_dev = mocked_controller[trim_light_trim_id]
+    trim_dev.color_mode.mode = "white"
+    resp = mocker.AsyncMock()
+    resp.status = 200
+    json_resp = mocker.AsyncMock()
+    json_resp.return_value = {"metadeviceId": trim_light.id, "values": []}
+    resp.json = json_resp
+    update_afero_api = mocker.patch.object(
+        mocked_controller, "update_afero_api", return_value=resp
+    )
+    await mocked_controller.set_white(trim_light_trim_id, on=None, brightness=40)
+    await mocked_controller._bridge.async_block_until_done()
+    sent_states = update_afero_api.call_args[0][1]
+    assert "color-mode" not in {s["functionClass"] for s in sent_states}
+
+
+@pytest.mark.asyncio
+async def test_set_state_temperature_respects_explicit_color_mode(
+    mocked_controller, mocker
+):
+    """Explicit color_mode must not be overridden when routing temperature on white-only."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    trim_dev = mocked_controller[trim_light_trim_id]
+    trim_dev.color_mode.mode = "white"
+    resp = mocker.AsyncMock()
+    resp.status = 200
+    json_resp = mocker.AsyncMock()
+    json_resp.return_value = {"metadeviceId": trim_light.id, "values": []}
+    resp.json = json_resp
+    update_afero_api = mocker.patch.object(
+        mocked_controller, "update_afero_api", return_value=resp
+    )
+    await mocked_controller.set_state(
+        trim_light_trim_id, on=True, temperature=2700, color_mode="color"
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    by_class = {
+        state["functionClass"]: state
+        for state in update_afero_api.call_args[0][1]
+    }
+    assert by_class["color-mode"]["value"] == "color"
+    assert "color-temperature" not in by_class
+
+
+@pytest.mark.asyncio
+async def test_update_elem_ignores_trim_zone_color_temperature_without_feature(
+    mocked_controller,
+):
+    """Inbound trim CCT rows must be ignored when the zone has no CCT feature."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    trim_dev = mocked_controller[trim_light_trim_id]
+    assert trim_dev.color_temperature is None
+    dev_update = AferoDevice(
+        id=trim_light_trim_id,
+        device_id=trim_light.device_id,
+        model=trim_light.model,
+        device_class="light",
+        default_name=trim_light.default_name,
+        default_image=trim_light.default_image,
+        friendly_name=trim_dev.device_information.name,
+        split_identifier="light",
+        states=[
+            AferoState(
+                functionClass="color-temperature",
+                value=3000,
+                lastUpdateTime=0,
+                functionInstance="trim",
+            )
+        ],
+    )
+    updates = await mocked_controller.update_elem(dev_update)
+    assert trim_dev.color_temperature is None
+    assert "color_temperature" not in updates
+
+
+@pytest.mark.asyncio
+async def test_set_state_temperature_routes_to_white_without_cct(
+    mocked_controller, mocker
+):
+    """set_state with temperature on white-only zones uses color-mode, not CCT."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    trim_dev = mocked_controller[trim_light_trim_id]
+    trim_dev.color_mode.mode = "color"
+    resp = mocker.AsyncMock()
+    resp.status = 200
+    json_resp = mocker.AsyncMock()
+    json_resp.return_value = {"metadeviceId": trim_light.id, "values": []}
+    resp.json = json_resp
+    update_afero_api = mocker.patch.object(
+        mocked_controller, "update_afero_api", return_value=resp
+    )
+    await mocked_controller.set_state(
+        trim_light_trim_id, on=True, temperature=2700, color_mode=None
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    update_afero_api.assert_called_once()
+    sent_states = update_afero_api.call_args[0][1]
+    by_class = {state["functionClass"]: state for state in sent_states}
+    assert by_class["color-mode"]["value"] == "white"
+    assert "color-temperature" not in by_class
+
+
+@pytest.mark.asyncio
+async def test_update_elem_trim_ignores_main_color_mode(mocked_controller):
+    """Inbound main color-mode must not change trim mode (e.g. main white vs trim RGB)."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    trim_dev = mocked_controller[trim_light_trim_id]
+    trim_mode = trim_dev.color_mode.mode
+    await mocked_controller.update_elem(
+        _trim_update_with_states(trim_dev, main_color_mode="white")
+    )
+    assert trim_dev.color_mode.mode == trim_mode
+
+
+@pytest.mark.asyncio
+async def test_update_elem_main_ignores_trim_power(mocked_controller):
+    """Inbound trim power must not change main on-state (symmetric with trim tests)."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    main_dev = mocked_controller[trim_light_primary_id]
+    main_dev.on.on = True
+    await mocked_controller.update_elem(
+        AferoDevice(
+            id=trim_light_primary_id,
+            device_id=trim_light.device_id,
+            model=trim_light.model,
+            device_class=ResourceTypes.LIGHT.value,
+            default_name=trim_light.default_name,
+            default_image=trim_light.default_image,
+            friendly_name=f"{trim_light.friendly_name} - main",
+            split_identifier="light",
+            states=[
+                AferoState(
+                    functionClass="power",
+                    value="off",
+                    lastUpdateTime=0,
+                    functionInstance="trim",
+                ),
+            ],
+        )
+    )
+    assert main_dev.on.on is True
+
+
+@pytest.mark.asyncio
+async def test_set_rgb_main_split(mocked_controller, mocker):
+    """Main split lights must target the main functionInstance, not trim."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-with-trim.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    main_dev = mocked_controller[trim_light_primary_id]
+    main_dev.on.on = False
+    resp = mocker.AsyncMock()
+    resp.status = 200
+    json_resp = mocker.AsyncMock()
+    json_resp.return_value = {"metadeviceId": trim_light.id, "values": []}
+    resp.json = json_resp
+    update_afero_api = mocker.patch.object(
+        mocked_controller, "update_afero_api", return_value=resp
+    )
+    await mocked_controller.set_rgb(trim_light_primary_id, 4, 5, 6)
+    await mocked_controller._bridge.async_block_until_done()
+    sent_states = update_afero_api.call_args[0][1]
+    instances = {
+        state["functionClass"]: state["functionInstance"] for state in sent_states
+    }
+    assert instances["color-rgb"] == "main"
+    assert instances["power"] == "main"
 
 
 @pytest.mark.asyncio

--- a/tests/v1/controllers/test_light.py
+++ b/tests/v1/controllers/test_light.py
@@ -464,6 +464,142 @@ def test_state_matches_instance_trim_zone(state, expected):
     assert state_matches_instance(trim_device, state) is expected
 
 
+@pytest.mark.parametrize(
+    "state, expected",
+    [
+        (
+            AferoState(
+                functionClass="color-rgb",
+                value={"color-rgb": {"r": 1, "g": 2, "b": 3}},
+                lastUpdateTime=0,
+                functionInstance=None,
+            ),
+            True,
+        ),
+        (
+            AferoState(
+                functionClass="color-mode",
+                value="color",
+                lastUpdateTime=0,
+                functionInstance=None,
+            ),
+            True,
+        ),
+        (
+            AferoState(
+                functionClass="toggle",
+                value="on",
+                lastUpdateTime=0,
+                functionInstance="color",
+            ),
+            True,
+        ),
+        (
+            AferoState(
+                functionClass="toggle",
+                value="off",
+                lastUpdateTime=0,
+                functionInstance="white",
+            ),
+            False,
+        ),
+        (
+            AferoState(
+                functionClass="brightness",
+                value=50,
+                lastUpdateTime=0,
+                functionInstance="primary",
+            ),
+            False,
+        ),
+    ],
+)
+def test_state_matches_instance_flushmount_color_zone(state, expected):
+    """LCN3002LM color zone uses null-instance color states."""
+    color_device = AferoDevice(
+        id=flushmount_light_color_id,
+        device_id=flushmount_light.device_id,
+        model=flushmount_light.model,
+        device_class="light",
+        default_name=flushmount_light.default_name,
+        default_image=flushmount_light.default_image,
+        friendly_name="color",
+        split_identifier="light",
+    )
+    assert state_matches_instance(color_device, state) is expected
+
+
+@pytest.mark.parametrize(
+    "state, expected",
+    [
+        (
+            AferoState(
+                functionClass="color-rgb",
+                value={"color-rgb": {"r": 1, "g": 2, "b": 3}},
+                lastUpdateTime=0,
+                functionInstance=None,
+            ),
+            False,
+        ),
+        (
+            AferoState(
+                functionClass="toggle",
+                value="on",
+                lastUpdateTime=0,
+                functionInstance="white",
+            ),
+            True,
+        ),
+    ],
+)
+def test_state_matches_instance_flushmount_white_zone(state, expected):
+    """LCN3002LM white zone must not inherit null-instance color states."""
+    white_device = AferoDevice(
+        id=flushmount_light_white_id,
+        device_id=flushmount_light.device_id,
+        model=flushmount_light.model,
+        device_class="light",
+        default_name=flushmount_light.default_name,
+        default_image=flushmount_light.default_image,
+        friendly_name="white",
+        split_identifier="light",
+    )
+    assert state_matches_instance(white_device, state) is expected
+
+
+@pytest.mark.asyncio
+async def test_update_elem_flushmount_color_applies_null_instance_rgb(mocked_controller):
+    """Inbound null-instance color-rgb must update the flushmount color split."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        utils.create_hs_raw_from_dump("light-flushmount.json")
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    color_dev = mocked_controller[flushmount_light_color_id]
+    color_update = AferoDevice(
+        id=flushmount_light_color_id,
+        device_id=flushmount_light.device_id,
+        model=flushmount_light.model,
+        device_class="light",
+        default_name=flushmount_light.default_name,
+        default_image=flushmount_light.default_image,
+        friendly_name=color_dev.device_information.name,
+        split_identifier="light",
+        states=[
+            AferoState(
+                functionClass="color-rgb",
+                value={"color-rgb": {"r": 10, "g": 20, "b": 30}},
+                lastUpdateTime=0,
+                functionInstance=None,
+            )
+        ],
+    )
+    updates = await mocked_controller.update_elem(color_update)
+    assert color_dev.color.red == 10
+    assert color_dev.color.green == 20
+    assert color_dev.color.blue == 30
+    assert "color" in updates
+
+
 @pytest.mark.asyncio
 async def test_parent_cache_keeps_full_states_after_trim_split(mocked_bridge):
     """Parent metadevice cache must stay the full device, not the parent-device shell."""

--- a/tests/v1/controllers/test_security_system.py
+++ b/tests/v1/controllers/test_security_system.py
@@ -25,6 +25,16 @@ def get_alarm_panel_with_siren() -> AferoDevice:
     return alarm_panel_with_siren
 
 
+def sync_panel_alarm_state(controller: SecuritySystemController, mode: str) -> None:
+    """Keep controller and bridge cache aligned (required after generate_update_dev merge)."""
+    controller[alarm_panel.id].alarm_state.mode = mode
+    cached = controller._bridge.get_afero_device(alarm_panel.id)
+    for state in cached.states:
+        if state.functionClass == "alarm-state":
+            state.value = mode
+            break
+
+
 @pytest.fixture
 def mocked_controller(mocked_bridge, mocker):
     mocker.patch("time.time", return_value=12345)
@@ -165,7 +175,7 @@ async def test_disarm(mocked_controller, mocker):
     )
     await mocked_controller._bridge.async_block_until_done()
     assert len(mocked_controller.items) == 1
-    mocked_controller[alarm_panel.id].alarm_state.mode = "arm-away"
+    sync_panel_alarm_state(mocked_controller, "arm-away")
     # Setup the response after disarm
     panel = utils.create_devices_from_data("security-system.json")[1]
     new_states = [
@@ -192,7 +202,7 @@ async def test_disarm_invalid_pin(mocked_controller, mocker):
     )
     await mocked_controller._bridge.async_block_until_done()
     assert len(mocked_controller.items) == 1
-    mocked_controller[alarm_panel.id].alarm_state.mode = "arm-away"
+    sync_panel_alarm_state(mocked_controller, "arm-away")
     # Setup the response after disarm
     panel = utils.create_devices_from_data("security-system.json")[1]
     new_states = [

--- a/tests/v1/controllers/test_switch.py
+++ b/tests/v1/controllers/test_switch.py
@@ -212,6 +212,44 @@ async def test_turn_on_split_device(mocked_bridge, mocker):
 
 
 @pytest.mark.asyncio
+async def test_turn_on_split_device_response_metadevice_id(mocked_bridge, mocker):
+    """PUT responses must merge parent cache even if metadeviceId echoes a split id."""
+    await mocked_bridge.generate_devices_from_data(
+        utils.create_devices_from_data("light-with-speaker.json")
+    )
+    await mocked_bridge.async_block_until_done()
+    speaker_id = "3bec6eaa-3d87-4f3c-a065-a2b32f87c39f-light-speaker-power"
+    parent_id = "3bec6eaa-3d87-4f3c-a065-a2b32f87c39f"
+    mocked_controller = mocked_bridge.switches
+    json_resp = mocker.AsyncMock()
+    json_resp.return_value = {
+        "metadeviceId": speaker_id,
+        "values": [
+            {
+                "functionClass": "toggle",
+                "functionInstance": "speaker-power",
+                "value": "on",
+                "lastUpdateTime": 0,
+            },
+        ],
+    }
+    resp = mocker.AsyncMock()
+    resp.json = json_resp
+    resp.status = 200
+    mocker.patch.object(mocked_controller, "update_afero_api", return_value=resp)
+    await mocked_controller.turn_on(speaker_id, instance="speaker-power")
+    await mocked_bridge.async_block_until_done()
+    parent = mocked_bridge.get_afero_device(parent_id)
+    assert any(
+        s.functionClass == "toggle"
+        and s.functionInstance == "speaker-power"
+        and s.value == "on"
+        for s in parent.states
+    )
+    assert mocked_controller[speaker_id].on["speaker-power"].on is True
+
+
+@pytest.mark.asyncio
 async def test_update_elem(mocked_controller):
     await mocked_controller._bridge.events.generate_events_from_data(
         [utils.create_hs_raw_from_device(transformer)]

--- a/tests/v1/test___init__.py
+++ b/tests/v1/test___init__.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -578,3 +579,88 @@ async def test_fetch_all_device_states(mocked_bridge, mocker, caplog):
     assert dev2.states == states2
     assert "Unable to fetch states: Boom" in caplog.text
     assert "Device dev4 not found in cache" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_device_states_dedupes_split_ids(mocked_bridge, mocker):
+    parent_id = "parent-light-id"
+    parent_dev = mocker.Mock(spec=AferoDevice)
+    parent_dev.id = parent_id
+    parent_dev.split_identifier = None
+    trim_dev = mocker.Mock(spec=AferoDevice)
+    trim_dev.id = f"{parent_id}-light-trim"
+    trim_dev.split_identifier = "light"
+    main_dev = mocker.Mock(spec=AferoDevice)
+    main_dev.id = f"{parent_id}-light-main"
+    main_dev.split_identifier = "light"
+    mocked_bridge._known_devs = {
+        f"{parent_id}-light-main": mocker.Mock(),
+        f"{parent_id}-light-trim": mocker.Mock(),
+    }
+    mocked_bridge._known_afero_devices = {
+        parent_id: parent_dev,
+        f"{parent_id}-light-main": main_dev,
+        f"{parent_id}-light-trim": trim_dev,
+    }
+    states = [AferoState(functionClass="power", value="on", functionInstance="trim")]
+    fetch = mocker.patch.object(
+        mocked_bridge,
+        "_fetch_device_states",
+        AsyncMock(return_value=(parent_id, states)),
+    )
+    updated_devices = await mocked_bridge.fetch_all_device_states()
+    fetch.assert_called_once_with(parent_id)
+    assert len(updated_devices) == 1
+    assert parent_dev.states == states
+
+
+def test_add_afero_dev_explicit_cache_key(mocked_bridge):
+    """add_afero_dev may store under an id other than device.id."""
+    device = AferoDevice(
+        id="canonical-id",
+        device_id="physical",
+        model="m",
+        device_class="light",
+        default_name="n",
+        default_image="i",
+        friendly_name="f",
+    )
+    mocked_bridge.add_afero_dev(device, "alias-cache-key")
+    assert mocked_bridge.get_afero_device("alias-cache-key") is device
+    with pytest.raises(DeviceNotFound):
+        mocked_bridge.get_afero_device("canonical-id")
+
+
+@pytest.mark.parametrize(
+    "device_id, expected",
+    [
+        ("plain-id", "plain-id"),
+        ("parent-light-id-light-main", "parent-light-id"),
+    ],
+)
+def test_resolve_metadevice_id(mocked_bridge, device_id, expected):
+    parent_dev = AferoDevice(
+        id="parent-light-id",
+        device_id="device",
+        model="m",
+        device_class="light",
+        default_name="n",
+        default_image="i",
+        friendly_name="f",
+    )
+    split_dev = AferoDevice(
+        id="parent-light-id-light-main",
+        device_id="device",
+        model="m",
+        device_class="light",
+        default_name="n",
+        default_image="i",
+        friendly_name="f",
+        split_identifier="light",
+    )
+    mocked_bridge._known_afero_devices = {
+        "plain-id": parent_dev,
+        "parent-light-id": parent_dev,
+        "parent-light-id-light-main": split_dev,
+    }
+    assert mocked_bridge.resolve_metadevice_id(device_id) == expected


### PR DESCRIPTION
- Poll parent metadevice IDs once; stop using synthetic split IDs for state fetch
- Cache split clones separately so the parent keeps full main/trim state
- Patch PUT response `values` into parent cache instead of replacing all states
- Filter inbound updates per split instance (main vs trim)
- Target outbound commands with split `elem.instance` (not metadata defaults)