### PR TITLE
Water-timer: full state parsing + per-device schedules

### DIFF
--- a/docs/schedules-polling-draft.md
+++ b/docs/schedules-polling-draft.md
@@ -1,0 +1,497 @@
+# Design draft: integrating `SchedulesController` with the polling/event model
+
+Status: **draft for maintainer review** (PR #64 follow-up). No source files changed.
+
+## Context
+
+PR #64 added `SchedulesController` at `src/aioafero/v1/controllers/schedules.py`. It is
+currently a **thin request client**: `get_schedules` / `create_schedule` /
+`delete_schedule` / `add_event` issue authenticated HTTP calls and return
+`DeviceSchedule` objects (`schedules.py:52-99`). It does not:
+
+- cache schedules,
+- poll/refresh them on a timer, or
+- emit add/update/delete events to subscribers,
+
+the way every other resource controller does via `BaseResourcesController`
+(`base.py:53`).
+
+The maintainer asked us to integrate schedules with the library's polling/event model
+(suggesting maybe an hourly refresh) and is undecided whether the controller should
+inherit `BaseResourcesController`.
+
+### Why schedules are different from every other resource (the load-bearing facts)
+
+These constraints drive the whole decision. Each is grounded in code I read:
+
+1. **Schedules are not metadevices and are not in the global device-state dump.**
+   The discovery poll (`AferoBridgeV1._fetch_data`, `__init__.py:402-436`) and the
+   device-state poll (`_fetch_all_device_states` →`_fetch_device_states`,
+   `__init__.py:460-506`) both hit `API_DEVICE_ENDPOINT` /
+   `API_DEVICE_STATE_ENDPOINT`. Schedules live behind a **separate endpoint** —
+   `API_DEVICE_SCHEDULES_ENDPOINT` = `/v1/accounts/{}/metadevices/{}/schedules`
+   (`v1_const.py:37`) — and must be fetched **per device** (`schedules.py:35-57`).
+   There is no payload field anywhere in the existing poll that carries schedules.
+
+2. **They are served by the data host via the `Host` header**, exactly like
+   `_fetch_device_states` and `BaseResourcesController.update_afero_api`
+   (`schedules.py:46-50`, mirrors `base.py:464-467` and `__init__.py:485-487`).
+   That part is already shared infrastructure, so either approach reuses
+   `bridge.request(...)` cleanly.
+
+3. **The base controller's whole intake path assumes an `AferoDevice` with
+   `states`.** `_handle_event` reads `evt_data["device"]` and routes it through
+   `initialize_elem(element: AferoDevice)` / `update_elem(element: AferoDevice)`
+   (`base.py:108-161`, `358-374`). Those events are produced exclusively by
+   `EventStream.generate_events_from_data` from the device dump
+   (`event.py:361-402`). A schedule is a `DeviceSchedule` (`models/schedules.py:141`),
+   not an `AferoDevice` with `functionClass`-shaped `states`, so it never enters that
+   pipeline.
+
+4. **`id` semantics are awkward.** `BaseResourcesController` keys `self._items` by the
+   metadevice id (`base.py:140`, `base.py:81-83`). A schedule's own id is
+   `DeviceSchedule.schedule_id` (server-assigned, `models/schedules.py:146`,
+   `from_afero` maps `data["id"]`, line 171), and a single device "typically holds a
+   single schedule object with multiple events" (`schedules.py:9-11`). So the natural
+   cache key is the **device id**, and the value is a *list* of schedules — not the
+   1-resource-per-id model the base class enforces.
+
+The cleanest available reuse is the **subscriber + event-dispatch machinery**
+(`emit_to_subscribers`, `subscribe`, `EventType`), which is decoupled from the device
+pipeline and can be reused verbatim. Both approaches below reuse it.
+
+---
+
+## Approach A — dedicated controller with a periodic refresh (recommended)
+
+Keep `SchedulesController` standalone (NOT a `BaseResourcesController`). Add an internal
+cache keyed by device id, a configurable refresh interval (default `3600`s), a
+background asyncio task started during bridge init, a `subscribe()` method copied from
+the base controller's semantics, and cache accessors. It emits the same `EventType`
+values (`RESOURCE_ADDED` / `RESOURCE_UPDATED` / `RESOURCE_DELETED`) through the same
+subscriber pattern as `BaseResourcesController.emit_to_subscribers` (`base.py:163-182`).
+
+### Code
+
+```python
+"""Client for Afero per-device schedules (with periodic refresh + events)."""
+
+import asyncio
+from asyncio.coroutines import iscoroutinefunction
+from collections.abc import Callable
+import contextlib
+from typing import TYPE_CHECKING
+
+from aioafero.types import EventType
+from aioafero.v1 import v1_const
+from aioafero.v1.controllers.base import EventSubscriptionType, ID_FILTER_ALL
+from aioafero.v1.models.schedules import (
+    DEFAULT_SCHEDULE_TAG,
+    DeviceSchedule,
+    ScheduleEvent,
+)
+
+if TYPE_CHECKING:
+    from aioafero.v1 import AferoBridgeV1
+
+DEFAULT_SCHEDULE_REFRESH_INTERVAL = 3600
+
+
+class SchedulesController:
+    """Manage per-device schedules with caching, refresh, and events."""
+
+    def __init__(
+        self,
+        bridge: "AferoBridgeV1",
+        refresh_interval: int = DEFAULT_SCHEDULE_REFRESH_INTERVAL,
+    ) -> None:
+        self._bridge = bridge
+        self._logger = bridge.logger.getChild("SchedulesController")
+        self._refresh_interval = refresh_interval
+        # device_id -> schedules currently on that device
+        self._items: dict[str, list[DeviceSchedule]] = {}
+        self._subscribers: dict[str, list[EventSubscriptionType]] = {
+            ID_FILTER_ALL: []
+        }
+        self._initialized = False
+        self._refresh_task: asyncio.Task | None = None
+
+    # ---- public read surface -------------------------------------------------
+
+    @property
+    def initialized(self) -> bool:
+        return self._initialized
+
+    @property
+    def items(self) -> dict[str, list[DeviceSchedule]]:
+        """All cached schedules keyed by device id."""
+        return dict(self._items)
+
+    def __getitem__(self, device_id: str) -> list[DeviceSchedule]:
+        return self._items.get(device_id, [])
+
+    def __contains__(self, device_id: str) -> bool:
+        return device_id in self._items
+
+    # ---- subscription (mirrors BaseResourcesController.subscribe) -------------
+
+    def subscribe(
+        self,
+        callback: Callable,
+        id_filter: str | tuple[str] | None = None,
+        event_filter: EventType | tuple[EventType] | None = None,
+    ) -> Callable:
+        """Subscribe to schedule add/update/delete events."""
+        if not isinstance(event_filter, (type(None), list, tuple)):
+            event_filter = (event_filter,)
+        if id_filter is None:
+            id_filter = (ID_FILTER_ALL,)
+        elif not isinstance(id_filter, (list, tuple)):
+            id_filter = (id_filter,)
+        subscription = (callback, event_filter)
+        for id_key in id_filter:
+            self._subscribers.setdefault(id_key, []).append(subscription)
+
+        def unsubscribe():
+            for id_key in id_filter:
+                with contextlib.suppress(ValueError, KeyError):
+                    self._subscribers[id_key].remove(subscription)
+
+        return unsubscribe
+
+    async def emit_to_subscribers(
+        self, evt_type: EventType, device_id: str, schedules: list[DeviceSchedule]
+    ) -> None:
+        """Dispatch an event for a device's schedules (see base.py:163-182)."""
+        subscribers = (
+            self._subscribers.get(device_id, []) + self._subscribers[ID_FILTER_ALL]
+        )
+        for callback, event_filter in subscribers:
+            if event_filter is not None and evt_type not in event_filter:
+                continue
+            if iscoroutinefunction(callback):
+                self._bridge.add_job(
+                    asyncio.create_task(callback(evt_type, schedules))
+                )
+            else:
+                callback(evt_type, schedules)
+
+    # ---- lifecycle -----------------------------------------------------------
+
+    async def initialize(self) -> None:
+        """Prime the cache for known devices and start the refresh loop."""
+        if self._initialized:
+            return
+        # Only refresh schedules for devices that actually support them
+        # (water timers today). Refresh once up front so consumers get a
+        # populated cache after the bridge's first poll.
+        await self.refresh()
+        self._refresh_task = asyncio.create_task(self.__refresh_loop())
+        self._bridge.track_scheduled_task(self._refresh_task)  # see lifecycle note
+        self._initialized = True
+
+    async def __refresh_loop(self) -> None:
+        with contextlib.suppress(asyncio.CancelledError):
+            while True:
+                await asyncio.sleep(self._refresh_interval)
+                with contextlib.suppress(Exception):
+                    await self.refresh()
+
+    def _schedule_device_ids(self) -> list[str]:
+        """Devices that can hold schedules. Today: tracked water-timer valves."""
+        return [valve.id for valve in self._bridge.valves]
+
+    async def refresh(self, device_ids: list[str] | None = None) -> None:
+        """Re-fetch schedules for the given (or all known) devices and emit diffs."""
+        targets = device_ids if device_ids is not None else self._schedule_device_ids()
+        for device_id in targets:
+            try:
+                latest = await self.get_schedules(device_id)
+            except Exception as err:  # network / auth / 4xx
+                self._logger.warning(
+                    "Unable to refresh schedules for %s: %s", device_id, err
+                )
+                continue
+            await self._apply_refresh(device_id, latest)
+        # Devices that dropped out of the tracked set get a delete.
+        for stale_id in set(self._items) - set(targets):
+            self._items.pop(stale_id, None)
+            await self.emit_to_subscribers(
+                EventType.RESOURCE_DELETED, stale_id, []
+            )
+
+    async def _apply_refresh(
+        self, device_id: str, latest: list[DeviceSchedule]
+    ) -> None:
+        previous = self._items.get(device_id)
+        if previous is None:
+            self._items[device_id] = latest
+            await self.emit_to_subscribers(
+                EventType.RESOURCE_ADDED, device_id, latest
+            )
+        elif previous != latest:  # dataclass __eq__ gives a deep compare
+            self._items[device_id] = latest
+            await self.emit_to_subscribers(
+                EventType.RESOURCE_UPDATED, device_id, latest
+            )
+
+    def _url(self, device_id, schedule_id=None):
+        ...  # unchanged from current schedules.py:35-44
+
+    def _headers(self):
+        ...  # unchanged from current schedules.py:46-50
+
+    async def get_schedules(self, device_id: str) -> list[DeviceSchedule]:
+        ...  # unchanged from current schedules.py:52-57
+
+    async def create_schedule(self, device_id, schedule):
+        result = ...  # current schedules.py:59-70 body
+        # Write-through: refresh just this device so subscribers see the change
+        # immediately instead of waiting up to refresh_interval.
+        await self.refresh(device_ids=[device_id])
+        return result
+
+    async def delete_schedule(self, device_id, schedule_id):
+        ...  # current schedules.py:72-77 body
+        await self.refresh(device_ids=[device_id])
+
+    async def add_event(self, device_id, event):
+        ...  # current schedules.py:79-99 body (calls create/delete, which refresh)
+```
+
+Two small bridge touch-points are required (called out as open questions, but trivial):
+
+- `AferoBridgeV1.initialize` already loops controllers and calls `controller.initialize()`
+  (`__init__.py:382-385`) — but `self.schedules` is **not** in `self._controllers`
+  (`__init__.py:184` sets it as a bare attribute). Either add it to `_controllers` via
+  `add_controller("schedules", SchedulesController)` (so init + the `controllers`
+  property pick it up automatically, `__init__.py:197-203`) or explicitly
+  `await self.schedules.initialize()` in `AferoBridgeV1.initialize`.
+- `close()` cancels `self._scheduled_tasks` (`__init__.py:313-318`). The refresh task
+  must land in that list — exposed above as a hypothetical
+  `bridge.track_scheduled_task(...)`; equivalently append directly to
+  `self._scheduled_tasks` or register via `initialize_cleanup`'s pattern.
+
+### How a consumer (Home Assistant) subscribes and gets updates
+
+```python
+def on_schedules(evt_type, schedules):  # schedules: list[DeviceSchedule]
+    ...
+unsub = bridge.schedules.subscribe(on_schedules, id_filter=valve_id)
+current = bridge.schedules[valve_id]  # immediate cached read
+```
+
+Identical ergonomics to `bridge.valves.subscribe(...)`. The only difference HA sees is
+that the callback payload is `list[DeviceSchedule]` rather than a single resource — a
+direct consequence of fact (4). `bridge.subscribe(...)` (the all-controllers helper,
+`__init__.py:324-342`) would need schedules added to `self.controllers` to be included;
+otherwise per-controller subscription works today.
+
+### Bridge lifecycle
+
+- **init:** one eager `refresh()` so the cache is warm, then the refresh loop. Fits
+  alongside the existing `add_job(asyncio.create_task(controller.initialize()))` fan-out
+  (`__init__.py:382-385`).
+- **first poll ordering:** `refresh()` depends on `self._bridge.valves` being populated,
+  which only happens after the first discovery poll
+  (`event.py:404-416`, `RESOURCE_ADDED` → `initialize_elem`). Safest is to do the eager
+  refresh lazily on first loop tick, or to subscribe to `bridge.valves` `RESOURCE_ADDED`
+  and prime that device's schedules then (best-of-both; see open questions).
+- **close:** refresh task cancelled with the other scheduled tasks (`__init__.py:313-318`).
+
+### Pros
+
+- Honors all four constraints above with zero violence to the base class.
+- Cache shape (`device_id -> list[DeviceSchedule]`) matches reality (one device, one
+  schedule object, many events).
+- Refresh interval is independent of `polling_interval`/`discovery_interval`; an hourly
+  schedule refresh does not add N per-device HTTP calls to the 30s state poll.
+- Write-through on create/delete gives consumers instant feedback without waiting an hour.
+- The existing thin-client methods are reused verbatim; lowest regression surface.
+
+### Cons
+
+- Duplicates ~30 lines of `subscribe`/`emit_to_subscribers` from `base.py:163-182, 376-414`.
+  (Mitigate by importing `ID_FILTER_ALL`/`EventSubscriptionType` from `base`, as shown,
+  or by factoring a tiny `SubscriberMixin` — see open questions.)
+- A second polling cadence to reason about and document.
+- `bridge.subscribe()` (all-controllers) won't include schedules unless schedules is
+  registered in `self._controllers`.
+
+### Test implications
+
+- New unit tests in `tests/v1/controllers/test_schedules.py` (file already exists):
+  feed two successive `get_schedules` fixtures, assert ADDED then UPDATED then DELETED
+  are emitted with the right payloads; assert `refresh` swallows per-device errors and
+  continues; assert write-through refresh fires after create/delete.
+- Use a fake/looped bridge with `refresh_interval=0`-ish and drive `refresh()` directly
+  rather than sleeping on the real loop (mirror how `test_event.py` drives the processor).
+- No change to other controllers' tests → **regression risk is low**.
+
+### Migration / regression risk
+
+- **Low.** Public method signatures of the thin client are unchanged; new behavior is
+  additive (cache + events + loop). Only new bridge wiring is the init/close hookup.
+
+---
+
+## Approach B — inherit `BaseResourcesController`
+
+Make schedules a first-class resource: `class SchedulesController(BaseResourcesController[DeviceSchedule])`.
+This is where the friction lives. Concretely:
+
+### Where it fights the base class
+
+1. **Intake path is device-dump-only.** `initialize()` subscribes to the event stream
+   filtered by `ITEM_TYPES` resource values (`base.py:209-226`), and events arrive only
+   from `generate_events_from_data` parsing the metadevice dump (`event.py:361-402`).
+   Schedules are **never** in that dump (fact 1). So `_handle_event` /
+   `_handle_event_type` (`base.py:108-161`) would never fire for schedules. We'd have to
+   **manufacture synthetic `AferoEvent`s** ourselves and inject them via
+   `bridge.events.add_job(...)` — i.e. rebuild Approach A's refresh loop *anyway*, just
+   feeding it through the device pipeline.
+
+2. **`initialize_elem`/`update_elem` expect an `AferoDevice` with `states`.**
+   Their signatures are `(element: AferoDevice)` and they read `functionClass`-shaped
+   states (`base.py:358-374`, see `ValveController.initialize_elem` `valve.py:87-151`).
+   A `DeviceSchedule` (`models/schedules.py:141`) has no `states`, no `functionClass`, no
+   `device_information`. To satisfy the base class we'd have to wrap each schedule in a
+   fake `AferoDevice` and re-derive it back out — pure impedance-matching with no payoff.
+   Worse, `_process_state_update` and `update()` (`base.py:416-447`, `488-530`) assume
+   `cur_item.device_information` and call `update_afero_api` with
+   `functionClass`/`value` state dicts — none of which a schedule has.
+
+3. **One-item-per-id vs list-per-device.** `self._items[item_id] = cur_item` stores a
+   single resource per id (`base.py:140`). Schedules are a *list* per device (fact 4).
+   We'd either flatten to one `DeviceSchedule` per device (lossy if a device ever has >1)
+   or key by `schedule_id` (server-assigned, unknown until after fetch — and `add_event`
+   deletes+recreates objects, so ids churn on every edit, `schedules.py:94-98`).
+
+4. **Host-header fetch.** Resources fetched per-device on the data host
+   (fact 2) — the base class only knows how to *write* to the data host
+   (`update_afero_api`, `base.py:449-486`); it has no per-resource GET path. We'd add one
+   regardless.
+
+5. **`get_filtered_devices` / `ITEM_TYPE_ID` / `ITEM_TYPES` don't apply.** They filter
+   the device dump by `typeId`/`deviceClass` (`base.py:184-204`). Schedules have neither.
+   These class attributes would be dead/misleading.
+
+### Sketch (showing the awkwardness)
+
+```python
+class SchedulesController(BaseResourcesController[DeviceSchedule]):
+    ITEM_TYPE_ID = ResourceTypes.DEVICE   # misleading: schedules aren't devices
+    ITEM_TYPES = [ResourceTypes.WATER_TIMER]
+    ITEM_CLS = DeviceSchedule             # has no .device_information / .states
+
+    async def initialize(self) -> None:
+        # CANNOT just call super().initialize(): that subscribes to the device
+        # event stream, which never carries schedules. Must run our own loop.
+        if self._initialized:
+            return
+        self._initialized = True
+        asyncio.create_task(self.__refresh_loop())  # same loop as Approach A
+
+    async def initialize_elem(self, element):  # element is NOT an AferoDevice here
+        # We'd have to invent an AferoDevice wrapper upstream so the base
+        # _handle_event_type path (base.py:132-141) can call this. Net: we fake
+        # a device, store one schedule, and lose the list-per-device shape.
+        ...
+
+    async def update_elem(self, element):
+        ...  # same impedance mismatch
+```
+
+Effectively Approach B re-implements Approach A's refresh loop **and** pays an
+adapter tax to shoehorn `DeviceSchedule` through an `AferoDevice`-shaped pipeline.
+
+### How a consumer subscribes
+
+Same `subscribe(callback, id_filter=..., event_filter=...)` surface for free
+(`base.py:376-414`) — this is the *one* genuine win. But the payload delivered through
+`emit_to_subscribers` (`base.py:163-182`) is a single `cur_item`, so the list-per-device
+reality is already broken at the seam.
+
+### Bridge lifecycle
+
+Would register naturally via `add_controller("schedules", ...)` and be picked up by
+`AferoBridgeV1.initialize` (`__init__.py:382-385`) and the `controllers` property
+(`__init__.py:197-203`) — a real ergonomic plus. But `super().initialize()` can't be
+used as-is (point 1), so most of that benefit is notional.
+
+### Pros
+
+- `subscribe()` / `emit_to_subscribers` / `items` / `__getitem__` inherited.
+- Auto-registration + inclusion in `bridge.subscribe()` and `bridge.controllers`.
+- "Looks like" every other controller to a casual reader.
+
+### Cons
+
+- Must override/bypass `initialize`, `initialize_elem`, `update_elem`, `update`,
+  `_handle_event` — i.e. most of the class — so the inheritance is mostly inert.
+- Forces a fake-`AferoDevice` adapter and a one-item-per-id model that doesn't match the
+  data (facts 3-4).
+- Dead/misleading class attributes (`ITEM_TYPE_ID`, `ITEM_TYPES`, `ITEM_MAPPING`).
+- Higher cognitive load: future maintainers will expect base-class semantics that don't
+  hold for schedules.
+
+### Test implications
+
+- Must construct fixtures that thread schedules through the synthetic-`AferoDevice`
+  adapter; tests assert on base-class internals (`_items`, `_handle_event`) that the real
+  data flow never exercises → brittle.
+- Risk of accidentally re-enabling the device-stream subscription and double-handling.
+
+### Migration / regression risk
+
+- **Moderate.** Touches shared base-class assumptions; a careless `super().initialize()`
+  would subscribe schedules to the device event stream and could mis-handle unrelated
+  device events. More surface to get wrong.
+
+---
+
+## Recommendation
+
+**Adopt Approach A.** Keep `SchedulesController` standalone, add a device-keyed cache,
+an independent (default `3600`s) refresh loop, a `subscribe()`/`emit_to_subscribers`
+pair that reuses the existing `EventType` + subscriber dispatch contract
+(`base.py:163-182`, `types.py:9-13`), and write-through refresh on create/delete.
+
+Rationale: schedules violate every structural assumption `BaseResourcesController` is
+built on — they're not metadevices, not in the device dump, fetched per-device on the
+data host, and are a list-per-device rather than one-resource-per-id (facts 1-4).
+Approach B inherits the class but then overrides almost all of it and adds an
+`AferoDevice` adapter, so it pays the cost of inheritance for almost none of the benefit.
+Approach A keeps the proven thin client intact and layers exactly the missing pieces
+(cache + events + timer), reusing the genuinely reusable part — the subscriber/event
+machinery — by import rather than inheritance.
+
+If duplicating ~30 lines of subscriber code is the sticking point, factor a small
+`SubscriberMixin` out of `BaseResourcesController` (`subscribe`, `emit_to_subscribers`,
+`_subscribers`, `ID_FILTER_ALL`) that both the base controller and `SchedulesController`
+share — best of both without forcing the device pipeline onto schedules.
+
+## Open questions for the maintainer
+
+1. **Registration:** register schedules via `add_controller("schedules", ...)` (so it's
+   in `bridge.controllers` and `bridge.subscribe()`), or keep it as the current bare
+   `self.schedules` attribute and wire init/close explicitly? The former is tidier but
+   means schedules show up in any code that iterates `bridge.controllers` expecting
+   `BaseResourcesController`-shaped objects.
+2. **Refresh trigger:** pure timer (default 3600s), or also prime/refresh a device's
+   schedules reactively when `bridge.valves` emits `RESOURCE_ADDED`? The reactive hook
+   avoids the first-poll ordering issue and gives instant warm cache.
+3. **Which devices get scheduled refresh?** Confirm the device set — today only water
+   timers (`ResourceTypes.WATER_TIMER`, `valve.py:48`) are known to carry schedules.
+   Should `_schedule_device_ids()` be driven by a capability check rather than hardcoding
+   valves?
+4. **Callback payload shape:** is `list[DeviceSchedule]` per device acceptable to HA, or
+   does the integration want one event per `DeviceSchedule`/per `ScheduleEvent`?
+5. **Write-through vs eventual:** OK to auto-`refresh()` the single device after
+   create/delete (one extra GET per mutation) for immediate subscriber feedback, or
+   prefer to wait for the next timer tick?
+6. **Shared subscriber code:** acceptable to extract a `SubscriberMixin` from
+   `BaseResourcesController`, or keep the ~30 lines duplicated in `SchedulesController`?
+7. **Default interval as a bridge param?** Should `refresh_interval` be plumbed through
+   `AferoBridgeV1.__init__` next to `polling_interval`/`discovery_interval`
+   (`__init__.py:124-137`) so consumers can tune it, or stay a controller-local constant?

--- a/src/aioafero/v1/__init__.py
+++ b/src/aioafero/v1/__init__.py
@@ -52,6 +52,7 @@ from .controllers.lock import LockController
 from .controllers.portable_ac import PortableACController
 from .controllers.security_system import SecuritySystemController
 from .controllers.security_system_keypad import SecuritySystemKeypadController
+from .controllers.schedules import SchedulesController
 from .controllers.security_system_sensor import SecuritySystemSensorController
 from .controllers.switch import SwitchController
 from .controllers.thermostat import ThermostatController
@@ -179,6 +180,8 @@ class AferoBridgeV1:
         self.add_controller("switches", SwitchController)
         self.add_controller("thermostats", ThermostatController)
         self.add_controller("valves", ValveController)
+        # Per-device schedule client (not a polled device controller).
+        self.schedules = SchedulesController(self)
 
     @property
     def refresh_token(self) -> str | None:

--- a/src/aioafero/v1/controllers/schedules.py
+++ b/src/aioafero/v1/controllers/schedules.py
@@ -14,7 +14,11 @@ schedule object with multiple events).
 from typing import TYPE_CHECKING
 
 from aioafero.v1 import v1_const
-from aioafero.v1.models.schedules import DeviceSchedule, ScheduleEvent
+from aioafero.v1.models.schedules import (
+    DEFAULT_SCHEDULE_TAG,
+    DeviceSchedule,
+    ScheduleEvent,
+)
 
 if TYPE_CHECKING:
     from aioafero.v1 import AferoBridgeV1
@@ -42,7 +46,7 @@ class SchedulesController:
     def _headers(self) -> dict[str, str]:
         # Device resources are served by the data host, addressed via Host header.
         return {
-            "host": v1_const.AFERO_CLIENTS[self._bridge._afero_client]["API_DATA_HOST"]
+            "host": v1_const.AFERO_CLIENTS[self._bridge.afero_client]["API_DATA_HOST"]
         }
 
     async def get_schedules(self, device_id: str) -> list[DeviceSchedule]:
@@ -83,7 +87,13 @@ class SchedulesController:
         existing = await self.get_schedules(device_id)
         events: list[ScheduleEvent] = [e for sched in existing for e in sched.events]
         events.append(event)
+        # Carry the existing schedule's opaque tag through the rebuild rather than
+        # resetting it to the default; the backend treats it as app-managed
+        # metadata and dropping it may change device-specific behaviour.
+        tag = existing[0].tag if existing else DEFAULT_SCHEDULE_TAG
         for sched in existing:
             if sched.schedule_id:
                 await self.delete_schedule(device_id, sched.schedule_id)
-        return await self.create_schedule(device_id, DeviceSchedule(events=events))
+        return await self.create_schedule(
+            device_id, DeviceSchedule(events=events, tag=tag)
+        )

--- a/src/aioafero/v1/controllers/schedules.py
+++ b/src/aioafero/v1/controllers/schedules.py
@@ -1,0 +1,89 @@
+"""Client for Afero per-device schedules.
+
+Schedules are not polled metadevices, so this is a thin client over the bridge's
+authenticated ``request`` (like the account-id lookup) rather than a
+``BaseResourcesController``. It targets
+``/v1/accounts/{accountId}/metadevices/{deviceId}/schedules`` on the data-host
+backend (addressed via the Host header, mirroring ``_fetch_device_states``).
+
+Exposes get/create/delete plus an ``add_event`` convenience that merges a new
+event into a device's existing schedule (each device typically holds a single
+schedule object with multiple events).
+"""
+
+from typing import TYPE_CHECKING
+
+from aioafero.v1 import v1_const
+from aioafero.v1.models.schedules import DeviceSchedule, ScheduleEvent
+
+if TYPE_CHECKING:
+    from aioafero.v1 import AferoBridgeV1
+
+
+class SchedulesController:
+    """Manage per-device schedules."""
+
+    def __init__(self, bridge: "AferoBridgeV1") -> None:
+        """Initialize with the owning bridge (auth, account id, requests)."""
+        self._bridge = bridge
+        self._logger = bridge.logger.getChild("SchedulesController")
+
+    def _url(self, device_id: str, schedule_id: str | None = None) -> str:
+        if schedule_id is None:
+            endpoint = v1_const.AFERO_GENERICS["API_DEVICE_SCHEDULES_ENDPOINT"].format(
+                self._bridge.account_id, device_id
+            )
+        else:
+            endpoint = v1_const.AFERO_GENERICS["API_DEVICE_SCHEDULE_ENDPOINT"].format(
+                self._bridge.account_id, device_id, schedule_id
+            )
+        return self._bridge.generate_api_url(endpoint)
+
+    def _headers(self) -> dict[str, str]:
+        # Device resources are served by the data host, addressed via Host header.
+        return {
+            "host": v1_const.AFERO_CLIENTS[self._bridge._afero_client]["API_DATA_HOST"]
+        }
+
+    async def get_schedules(self, device_id: str) -> list[DeviceSchedule]:
+        """List the schedule objects on a device."""
+        res = await self._bridge.request("GET", self._url(device_id), headers=self._headers())
+        res.raise_for_status()
+        data = await res.json()
+        return [DeviceSchedule.from_afero(s) for s in data or []]
+
+    async def create_schedule(
+        self, device_id: str, schedule: DeviceSchedule
+    ) -> DeviceSchedule:
+        """Create a schedule object on a device."""
+        res = await self._bridge.request(
+            "POST",
+            self._url(device_id),
+            headers=self._headers(),
+            json=schedule.to_afero(),
+        )
+        res.raise_for_status()
+        return DeviceSchedule.from_afero(await res.json())
+
+    async def delete_schedule(self, device_id: str, schedule_id: str) -> None:
+        """Delete a schedule object from a device."""
+        res = await self._bridge.request(
+            "DELETE", self._url(device_id, schedule_id), headers=self._headers()
+        )
+        res.raise_for_status()
+
+    async def add_event(
+        self, device_id: str, event: ScheduleEvent
+    ) -> DeviceSchedule:
+        """Add an event to a device's schedule, preserving existing events.
+
+        A device holds a single schedule object, so this fetches the current
+        events, deletes the existing object(s), and posts the merged set.
+        """
+        existing = await self.get_schedules(device_id)
+        events: list[ScheduleEvent] = [e for sched in existing for e in sched.events]
+        events.append(event)
+        for sched in existing:
+            if sched.schedule_id:
+                await self.delete_schedule(device_id, sched.schedule_id)
+        return await self.create_schedule(device_id, DeviceSchedule(events=events))

--- a/src/aioafero/v1/controllers/valve.py
+++ b/src/aioafero/v1/controllers/valve.py
@@ -1,25 +1,55 @@
 """Controller holding and managing Afero IoT resources of type `valve`."""
 
+from typing import Any
+
 from aioafero import errors
-from aioafero.device import AferoDevice
+from aioafero.device import AferoDevice, get_function_from_device
 from aioafero.v1.models import features
 from aioafero.v1.models.resource import DeviceInformation, ResourceTypes
 from aioafero.v1.models.valve import Valve, ValvePut
 
 from .base import AferoBinarySensor, AferoSensor, BaseResourcesController
 
+# Per-spigot numeric functions. These are instanced (``spigot-1``, ``spigot-2``,
+# ...) so they cannot be enumerated statically in ITEM_NUMBERS; they are parsed
+# by functionClass and stored in the ``numbers`` dict keyed by (class, instance).
+NUMBER_CLASSES = {"timer", "max-on-time"}
+# Display units for the per-spigot numbers. Both are 0/1-360 on the known
+# fixtures and represent durations in minutes. ``max-on-time`` is documented as
+# 1-360 minutes; ``timer``'s unit is inferred from its shared range and should
+# be confirmed against live hardware (see k3s-q9l7 sub-task 5 traffic capture).
+NUMBER_UNITS = {"timer": "minutes", "max-on-time": "minutes"}
+
+
+def _rain_delay_pauses(value: Any) -> list:
+    """Pull the pause-window list out of a `schedule-pause`/`rain-delay` value.
+
+    Wire shape:
+        {"schedule-pause-time-array": {"schedulePauseTimeArray": [...]}}
+    Tolerant of a missing/short payload -- returns an empty list rather than
+    raising so a partial device dump still parses.
+    """
+    if not isinstance(value, dict):
+        return []
+    nested = value.get("schedule-pause-time-array") or {}
+    return list(nested.get("schedulePauseTimeArray") or [])
+
 
 class ValveController(BaseResourcesController[Valve]):
     """Controller holding and managing Afero IoT resources of type `valve`.
 
-    A valve can have one or more toggleable elements. They are controlled
-    by their functionInstance.
+    A valve can have one or more toggleable elements (spigots). Each spigot is
+    controlled by its functionInstance and carries a ``timer`` and
+    ``max-on-time`` number. The device also exposes a ``battery-level`` sensor
+    and a ``schedule-pause`` (rain-delay) feature.
     """
 
     ITEM_TYPE_ID = ResourceTypes.DEVICE
     ITEM_TYPES = [ResourceTypes.WATER_TIMER]
     ITEM_CLS = Valve
     ITEM_MAPPING = {}
+    # Sensors map functionClass -> Unit
+    ITEM_SENSORS: dict[str, str] = {"battery-level": "%"}
 
     async def turn_on(self, device_id: str, instance: str | None = None) -> None:
         """Open the valve."""
@@ -28,6 +58,31 @@ class ValveController(BaseResourcesController[Valve]):
     async def turn_off(self, device_id: str, instance: str | None = None) -> None:
         """Close the valve."""
         await self.set_state(device_id, valve_open=False, instance=instance)
+
+    def _number_feature(
+        self, afero_device: AferoDevice, state
+    ) -> features.NumbersFeature:
+        """Build a NumbersFeature for a per-spigot numeric state.
+
+        Mirrors ``BaseResourcesController.initialize_number`` but matches by
+        functionClass rather than an exact (class, instance) key, so any number
+        of spigots is supported.
+        """
+        func_def = get_function_from_device(
+            afero_device.functions, state.functionClass, state.functionInstance
+        )
+        working_def = func_def["values"][0]
+        fallback_name = state.functionClass
+        if state.functionInstance is not None:
+            fallback_name += f"-{state.functionInstance}"
+        return features.NumbersFeature(
+            value=state.value,
+            min=working_def["range"]["min"],
+            max=working_def["range"]["max"],
+            step=working_def["range"]["step"],
+            name=working_def.get("name", fallback_name),
+            unit=NUMBER_UNITS.get(state.functionClass),
+        )
 
     async def initialize_elem(self, afero_device: AferoDevice) -> Valve:
         """Initialize the element.
@@ -38,9 +93,13 @@ class ValveController(BaseResourcesController[Valve]):
         """
         self._logger.info("Initializing %s", afero_device.id)
         available: bool = False
-        valve_open: dict[str, features.OpenFeature] = {}
+        valve_open: dict[str | None, features.OpenFeature] = {}
+        numbers: dict[tuple[str, str | None], features.NumbersFeature] = {}
         sensors: dict[str, AferoSensor] = {}
         binary_sensors: dict[str, AferoBinarySensor] = {}
+        rain_delay_active: bool = False
+        rain_delay_pauses: list = []
+        rain_delay_seen: bool = False
         for state in afero_device.states:
             if state.functionClass in ["power", "toggle"]:
                 valve_open[state.functionInstance] = features.OpenFeature(
@@ -48,8 +107,20 @@ class ValveController(BaseResourcesController[Valve]):
                     func_class=state.functionClass,
                     func_instance=state.functionInstance,
                 )
+            elif state.functionClass in NUMBER_CLASSES:
+                numbers[(state.functionClass, state.functionInstance)] = (
+                    self._number_feature(afero_device, state)
+                )
+            elif state.functionClass == "schedule-pause":
+                rain_delay_seen = True
+                if state.functionInstance == "active":
+                    rain_delay_active = state.value == "on"
+                elif state.functionInstance == "rain-delay":
+                    rain_delay_pauses = _rain_delay_pauses(state.value)
             elif state.functionClass == "available":
                 available = state.value
+            elif sensor := await self.initialize_sensor(state, afero_device.id):
+                sensors[sensor.id] = sensor
 
         self._items[afero_device.id] = Valve(
             _id=afero_device.id,
@@ -68,8 +139,32 @@ class ValveController(BaseResourcesController[Valve]):
                 functions=afero_device.functions,
             ),
             open=valve_open,
+            numbers=numbers,
+            rain_delay=(
+                features.RainDelayFeature(
+                    active=rain_delay_active, pauses=rain_delay_pauses
+                )
+                if rain_delay_seen
+                else None
+            ),
         )
         return self._items[afero_device.id]
+
+    def _update_rain_delay(self, cur_item: Valve, state) -> bool:
+        """Apply a `schedule-pause` state to the item. Returns True if changed."""
+        if cur_item.rain_delay is None:
+            cur_item.rain_delay = features.RainDelayFeature(active=False)
+        if state.functionInstance == "active":
+            new_active = state.value == "on"
+            if cur_item.rain_delay.active != new_active:
+                cur_item.rain_delay.active = new_active
+                return True
+        elif state.functionInstance == "rain-delay":
+            new_pauses = _rain_delay_pauses(state.value)
+            if cur_item.rain_delay.pauses != new_pauses:
+                cur_item.rain_delay.pauses = new_pauses
+                return True
+        return False
 
     async def update_elem(self, afero_device: AferoDevice) -> set:
         """Update the Valve with the latest API data.
@@ -86,10 +181,20 @@ class ValveController(BaseResourcesController[Valve]):
                 if cur_item.open[state.functionInstance].open != new_state:
                     updated_keys.add("open")
                 cur_item.open[state.functionInstance].open = new_state
+            elif state.functionClass in NUMBER_CLASSES:
+                key = (state.functionClass, state.functionInstance)
+                if key in cur_item.numbers and cur_item.numbers[key].value != state.value:
+                    cur_item.numbers[key].value = state.value
+                    updated_keys.add(f"number-{key}")
+            elif state.functionClass == "schedule-pause":
+                if self._update_rain_delay(cur_item, state):
+                    updated_keys.add("rain-delay")
             elif state.functionClass == "available":
                 if cur_item.available != state.value:
                     updated_keys.add("available")
                 cur_item.available = state.value
+            elif update_key := await self.update_sensor(state, cur_item):
+                updated_keys.add(update_key)
 
         return updated_keys
 
@@ -98,8 +203,10 @@ class ValveController(BaseResourcesController[Valve]):
         device_id: str,
         valve_open: bool | None = None,
         instance: str | None = None,
+        numbers: dict[tuple[str, str | None], float] | None = None,
+        rain_delay: bool | None = None,
     ) -> None:
-        """Set supported feature(s) to fan resource."""
+        """Set supported feature(s) on the valve resource."""
         update_obj = ValvePut()
         try:
             cur_item = self.get_device(device_id)
@@ -115,4 +222,18 @@ class ValveController(BaseResourcesController[Valve]):
                 )
             except KeyError:
                 self._logger.info("Unable to find instance %s", instance)
+        if numbers:
+            for key, val in numbers.items():
+                if key not in cur_item.numbers:
+                    continue
+                update_obj.numbers[key] = features.NumbersFeature(
+                    value=val,
+                    min=cur_item.numbers[key].min,
+                    max=cur_item.numbers[key].max,
+                    step=cur_item.numbers[key].step,
+                    name=cur_item.numbers[key].name,
+                    unit=cur_item.numbers[key].unit,
+                )
+        if rain_delay is not None:
+            update_obj.rain_delay = features.RainDelayFeature(active=rain_delay)
         await self.update(device_id, obj_in=update_obj)

--- a/src/aioafero/v1/controllers/valve.py
+++ b/src/aioafero/v1/controllers/valve.py
@@ -16,8 +16,8 @@ from .base import AferoBinarySensor, AferoSensor, BaseResourcesController
 NUMBER_CLASSES = {"timer", "max-on-time"}
 # Display units for the per-spigot numbers. Both are 0/1-360 on the known
 # fixtures and represent durations in minutes. ``max-on-time`` is documented as
-# 1-360 minutes; ``timer``'s unit is inferred from its shared range and should
-# be confirmed against live hardware (see k3s-q9l7 sub-task 5 traffic capture).
+# 1-360 minutes; ``timer``'s unit is inferred from its shared range and is worth
+# confirming against live hardware.
 NUMBER_UNITS = {"timer": "minutes", "max-on-time": "minutes"}
 
 
@@ -240,7 +240,13 @@ class ValveController(BaseResourcesController[Valve]):
                 active=bool(rain_delay_windows), pause_windows=rain_delay_windows
             )
         elif rain_delay is not None:
-            update_obj.rain_delay = features.RainDelayFeature(active=rain_delay)
+            # Carry over the device's existing pause windows so toggling only
+            # ``active`` compares equal to current state when it is a no-op (and
+            # can be skipped). pause_windows stays None, so nothing is rewritten.
+            existing_pauses = cur_item.rain_delay.pauses if cur_item.rain_delay else []
+            update_obj.rain_delay = features.RainDelayFeature(
+                active=rain_delay, pauses=existing_pauses
+            )
         await self.update(device_id, obj_in=update_obj)
 
     async def set_rain_delay(

--- a/src/aioafero/v1/controllers/valve.py
+++ b/src/aioafero/v1/controllers/valve.py
@@ -205,6 +205,7 @@ class ValveController(BaseResourcesController[Valve]):
         instance: str | None = None,
         numbers: dict[tuple[str, str | None], float] | None = None,
         rain_delay: bool | None = None,
+        rain_delay_windows: list[dict] | None = None,
     ) -> None:
         """Set supported feature(s) on the valve resource."""
         update_obj = ValvePut()
@@ -234,6 +235,21 @@ class ValveController(BaseResourcesController[Valve]):
                     name=cur_item.numbers[key].name,
                     unit=cur_item.numbers[key].unit,
                 )
-        if rain_delay is not None:
+        if rain_delay_windows is not None:
+            update_obj.rain_delay = features.RainDelayFeature(
+                active=bool(rain_delay_windows), pause_windows=rain_delay_windows
+            )
+        elif rain_delay is not None:
             update_obj.rain_delay = features.RainDelayFeature(active=rain_delay)
         await self.update(device_id, obj_in=update_obj)
+
+    async def set_rain_delay(
+        self, device_id: str, start_epoch: int, end_epoch: int
+    ) -> None:
+        """Pause the device's schedule for a window (epoch seconds) -- a rain delay."""
+        window = features.RainDelayFeature.pause_window(start_epoch, end_epoch)
+        await self.set_state(device_id, rain_delay_windows=[window])
+
+    async def clear_rain_delay(self, device_id: str) -> None:
+        """Clear any rain delay on the device."""
+        await self.set_state(device_id, rain_delay_windows=[])

--- a/src/aioafero/v1/controllers/valve.py
+++ b/src/aioafero/v1/controllers/valve.py
@@ -178,9 +178,20 @@ class ValveController(BaseResourcesController[Valve]):
         for state in afero_device.states:
             if state.functionClass in ["power", "toggle"]:
                 new_state = state.value == "on"
-                if cur_item.open[state.functionInstance].open != new_state:
+                existing = cur_item.open.get(state.functionInstance)
+                if existing is None:
+                    # A spigot/power instance can appear in an update that wasn't
+                    # in the initial states -- add it rather than KeyError.
+                    cur_item.open[state.functionInstance] = features.OpenFeature(
+                        open=new_state,
+                        func_class=state.functionClass,
+                        func_instance=state.functionInstance,
+                    )
                     updated_keys.add("open")
-                cur_item.open[state.functionInstance].open = new_state
+                else:
+                    if existing.open != new_state:
+                        updated_keys.add("open")
+                    existing.open = new_state
             elif state.functionClass in NUMBER_CLASSES:
                 key = (state.functionClass, state.functionInstance)
                 if key in cur_item.numbers and cur_item.numbers[key].value != state.value:

--- a/src/aioafero/v1/models/features.py
+++ b/src/aioafero/v1/models/features.py
@@ -264,21 +264,55 @@ class RainDelayFeature:
       * `schedule-pause` @ `rain-delay` (object) -- the configured pause windows,
         wrapped as ``{"schedule-pause-time-array": {"schedulePauseTimeArray": [...]}}``.
 
-    ``api_value`` only emits the `active` toggle; the pause-window array is created
-    and managed in the Hubspace app and is surfaced here read-only.
+    ``active`` and ``pauses`` are read from the device (``active`` is a
+    device-computed status: whether now falls inside a window). To WRITE a timed
+    pause (rain delay), set ``pause_windows`` to a list of window entries built
+    with :meth:`pause_window`; ``api_value`` then emits both the window array and
+    the ``active`` mirror. ``pause_windows=[]`` clears the rain delay.
     """
 
     active: bool
     pauses: list[Any] = field(default_factory=list)
+    # Windows to WRITE (None = emit only the active toggle; [] = clear).
+    pause_windows: list[dict] | None = None
+
+    @staticmethod
+    def pause_window(start_epoch: int, end_epoch: int, *, flags: int = 0, version: int = 1) -> dict:
+        """Build one pause-window entry (times in epoch SECONDS)."""
+        return {
+            "version": version,
+            "flags": flags,
+            "startTime": int(start_epoch),
+            "endTime": int(end_epoch),
+        }
 
     @property
     def api_value(self):
-        """Value to send to Afero API to toggle the rain delay on/off."""
-        return {
-            "functionClass": "schedule-pause",
-            "functionInstance": "active",
-            "value": "on" if self.active else "off",
-        }
+        """Value(s) to send to Afero API."""
+        if self.pause_windows is None:
+            # Plain active toggle (legacy behavior).
+            return {
+                "functionClass": "schedule-pause",
+                "functionInstance": "active",
+                "value": "on" if self.active else "off",
+            }
+        # Write the window array plus the active mirror (empty list = clear).
+        return [
+            {
+                "functionClass": "schedule-pause",
+                "functionInstance": "active",
+                "value": "on" if self.pause_windows else "off",
+            },
+            {
+                "functionClass": "schedule-pause",
+                "functionInstance": "rain-delay",
+                "value": {
+                    "schedule-pause-time-array": {
+                        "schedulePauseTimeArray": list(self.pause_windows)
+                    }
+                },
+            },
+        ]
 
 
 @dataclass

--- a/src/aioafero/v1/models/features.py
+++ b/src/aioafero/v1/models/features.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Any
 
 from aioafero.util import percentage_to_ordered_list_item
 
@@ -254,6 +255,33 @@ class OpenFeature:
 
 
 @dataclass
+class RainDelayFeature:
+    """Represent the rain-delay / schedule-pause state of a water timer.
+
+    Two wire states feed this single feature:
+      * `schedule-pause` @ `active` (category `on`/`off`) -- whether a pause is
+        currently in effect.
+      * `schedule-pause` @ `rain-delay` (object) -- the configured pause windows,
+        wrapped as ``{"schedule-pause-time-array": {"schedulePauseTimeArray": [...]}}``.
+
+    ``api_value`` only emits the `active` toggle; the pause-window array is created
+    and managed in the Hubspace app and is surfaced here read-only.
+    """
+
+    active: bool
+    pauses: list[Any] = field(default_factory=list)
+
+    @property
+    def api_value(self):
+        """Value to send to Afero API to toggle the rain delay on/off."""
+        return {
+            "functionClass": "schedule-pause",
+            "functionInstance": "active",
+            "value": "on" if self.active else "off",
+        }
+
+
+@dataclass
 class PresetFeature:
     """Represent the current preset."""
 
@@ -402,6 +430,7 @@ AferoFeatures: list = [
     NumbersFeature,
     OnFeature,
     OpenFeature,
+    RainDelayFeature,
     PresetFeature,
     SelectFeature,
     SpeedFeature,

--- a/src/aioafero/v1/models/schedules.py
+++ b/src/aioafero/v1/models/schedules.py
@@ -86,8 +86,16 @@ class ScheduleEvent:
 
     @classmethod
     def from_afero(cls, data: dict) -> ScheduleEvent:
-        """Build from an Afero API event object."""
-        sv = (data.get("semanticValues") or [{}])[0]
+        """Build from an Afero API event object.
+
+        Raises ValueError when the event carries no ``semanticValues``: without
+        one there is no function instance to act on, and defaulting it silently
+        would later emit an invalid ``functionInstance: null`` payload.
+        """
+        sv_list = data.get("semanticValues") or []
+        if not sv_list:
+            raise ValueError("schedule event is missing semanticValues")
+        sv = sv_list[0]
         return cls(
             function_instance=sv.get("functionInstance"),
             value=sv.get("value"),
@@ -142,15 +150,17 @@ class DeviceSchedule:
     device_attribute_data: str | None = None
 
     def to_afero(self) -> dict[str, Any]:
-        """Value to send to the Afero API. ``scheduleId`` is omitted on create;
-        ``deviceAttributeData`` is derived by the backend from ``events``."""
-        payload: dict[str, Any] = {
+        """Value to POST when creating a schedule -- only ``tag`` + ``events``.
+
+        ``scheduleId`` is server-assigned and ``deviceAttributeData`` is derived
+        by the backend from ``events``, so neither is sent. Create is the only
+        POST path (there is no id-round-tripping update), so a fetched schedule
+        re-posted here will not leak its id back to the backend.
+        """
+        return {
             "tag": self.tag,
             "events": [e.to_afero() for e in self.events],
         }
-        if self.schedule_id is not None:
-            payload["scheduleId"] = self.schedule_id
-        return payload
 
     @classmethod
     def from_afero(cls, data: dict) -> DeviceSchedule:

--- a/src/aioafero/v1/models/schedules.py
+++ b/src/aioafero/v1/models/schedules.py
@@ -1,0 +1,164 @@
+"""Representation of Afero per-device schedules.
+
+These are recurring on-device events (stored in a device attribute, encoded by
+the backend), exposed at ``/v1/accounts/{accountId}/metadevices/{deviceId}/schedules``
+on the data-host backend. A device holds one (or more) ``DeviceSchedule``
+objects, each with a list of ``ScheduleEvent``s. An event runs a device function
+(e.g. a water timer's ``timer``/``spigot-1`` for N minutes) at a time, either on
+fixed ``daysOfWeek`` (ABSOLUTE) or every ``intervalDays`` (PERIODIC).
+
+Wire payloads use camelCase; these dataclasses use snake_case with
+``to_afero``/``from_afero`` converters.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# Day-of-week enum used by the event ``daysOfWeek`` array.
+DAYS_OF_WEEK: tuple[str, ...] = (
+    "SUNDAY",
+    "MONDAY",
+    "TUESDAY",
+    "WEDNESDAY",
+    "THURSDAY",
+    "FRIDAY",
+    "SATURDAY",
+)
+# Opaque tag the app stores on each schedule object; round-tripped on create.
+DEFAULT_SCHEDULE_TAG = '{"version":2,"outlet":null,"weekly":null,"index":null}'
+
+
+def normalize_days(days) -> list[str]:
+    """Coerce day names/abbreviations (any case) into the Afero enum.
+
+    Raises ValueError on an unknown day so a typo fails loudly.
+    """
+    out: list[str] = []
+    for day in days or []:
+        code = str(day).strip().upper()[:3]
+        full = next((d for d in DAYS_OF_WEEK if d.startswith(code)), None)
+        if full is None:
+            raise ValueError(f"Unknown day of week: {day!r}")
+        if full not in out:
+            out.append(full)
+    return out
+
+
+@dataclass
+class ScheduleEvent:
+    """A single recurring action within a schedule."""
+
+    function_instance: str  # e.g. "spigot-1"
+    value: Any  # the value to set (e.g. timer minutes)
+    hour: int
+    minute: int
+    function_class: str = "timer"
+    days_of_week: list[str] = field(default_factory=list)  # ABSOLUTE
+    time_type: str = "ABSOLUTE"  # or "PERIODIC"
+    interval_days: int = 0  # PERIODIC: run every N days
+    start_date_local: dict | None = None  # PERIODIC: {year,month,day,hour,minute}
+    enabled: bool = True
+    utc: bool = False
+
+    def to_afero(self) -> dict[str, Any]:
+        """Value to send to the Afero API (server assigns ids)."""
+        payload: dict[str, Any] = {
+            "enabled": self.enabled,
+            "timeType": self.time_type,
+            "daysOfWeek": list(self.days_of_week),
+            "utc": self.utc,
+            "intervalDays": self.interval_days,
+            "hour": self.hour,
+            "minute": self.minute,
+            "semanticValues": [
+                {
+                    "functionClass": self.function_class,
+                    "functionInstance": self.function_instance,
+                    "value": self.value,
+                }
+            ],
+        }
+        if self.start_date_local is not None:
+            payload["startDateLocal"] = self.start_date_local
+        return payload
+
+    @classmethod
+    def from_afero(cls, data: dict) -> ScheduleEvent:
+        """Build from an Afero API event object."""
+        sv = (data.get("semanticValues") or [{}])[0]
+        return cls(
+            function_instance=sv.get("functionInstance"),
+            value=sv.get("value"),
+            function_class=sv.get("functionClass", "timer"),
+            hour=data.get("hour", 0),
+            minute=data.get("minute", 0),
+            days_of_week=list(data.get("daysOfWeek", [])),
+            time_type=data.get("timeType", "ABSOLUTE"),
+            interval_days=data.get("intervalDays", 0),
+            start_date_local=data.get("startDateLocal"),
+            enabled=data.get("enabled", True),
+            utc=data.get("utc", False),
+        )
+
+    @classmethod
+    def weekly(
+        cls,
+        function_instance: str,
+        value: Any,
+        hour: int,
+        minute: int,
+        days=None,
+        function_class: str = "timer",
+        enabled: bool = True,
+    ) -> ScheduleEvent:
+        """Convenience builder for an ABSOLUTE weekly event (all days if none)."""
+        if not 0 <= hour <= 23:
+            raise ValueError(f"hour must be 0-23, got {hour}")
+        if not 0 <= minute <= 59:
+            raise ValueError(f"minute must be 0-59, got {minute}")
+        resolved = normalize_days(days) if days else list(DAYS_OF_WEEK)
+        return cls(
+            function_instance=function_instance,
+            value=value,
+            hour=hour,
+            minute=minute,
+            function_class=function_class,
+            days_of_week=resolved,
+            enabled=enabled,
+        )
+
+
+@dataclass
+class DeviceSchedule:
+    """A schedule object on a device, holding one or more events."""
+
+    events: list[ScheduleEvent] = field(default_factory=list)
+    schedule_id: str | None = None
+    tag: str = DEFAULT_SCHEDULE_TAG
+    # Set by the backend; read-only for callers.
+    device_attribute_id: int | None = None
+    device_attribute_data: str | None = None
+
+    def to_afero(self) -> dict[str, Any]:
+        """Value to send to the Afero API. ``scheduleId`` is omitted on create;
+        ``deviceAttributeData`` is derived by the backend from ``events``."""
+        payload: dict[str, Any] = {
+            "tag": self.tag,
+            "events": [e.to_afero() for e in self.events],
+        }
+        if self.schedule_id is not None:
+            payload["scheduleId"] = self.schedule_id
+        return payload
+
+    @classmethod
+    def from_afero(cls, data: dict) -> DeviceSchedule:
+        """Build from an Afero API schedule object."""
+        return cls(
+            events=[ScheduleEvent.from_afero(e) for e in data.get("events", [])],
+            schedule_id=data.get("id"),
+            tag=data.get("tag", DEFAULT_SCHEDULE_TAG),
+            device_attribute_id=data.get("deviceAttributeId"),
+            device_attribute_data=data.get("deviceAttributeData"),
+        )

--- a/src/aioafero/v1/models/valve.py
+++ b/src/aioafero/v1/models/valve.py
@@ -10,11 +10,18 @@ from .standard_mixin import StandardMixin
 
 @dataclass(kw_only=True)
 class Valve(StandardMixin):
-    """Representation of an Afero Valve."""
+    """Representation of an Afero Valve.
+
+    ``open`` holds the master ``power`` switch (instance ``None``) and each
+    spigot's ``toggle``. Per-spigot ``timer`` and ``max-on-time`` values live in
+    the inherited ``numbers`` dict (keyed by ``(functionClass, functionInstance)``)
+    and ``battery-level`` lives in the inherited ``sensors`` dict.
+    """
 
     type: ResourceTypes = ResourceTypes.WATER_TIMER
 
     open: dict[str | None, features.OpenFeature] = field(default_factory=dict)
+    rain_delay: features.RainDelayFeature | None = None
 
 
 @dataclass
@@ -22,3 +29,7 @@ class ValvePut:
     """States that can be updated for a Valve."""
 
     open: features.OpenFeature | None = None
+    numbers: dict[tuple[str, str | None], features.NumbersFeature] | None = field(
+        default_factory=dict, repr=False, init=False
+    )
+    rain_delay: features.RainDelayFeature | None = None

--- a/src/aioafero/v1/v1_const.py
+++ b/src/aioafero/v1/v1_const.py
@@ -32,6 +32,10 @@ AFERO_GENERICS: Final[dict[str, str]] = {
     "API_DEVICE_ENDPOINT": "/v1/accounts/{}/metadevices",
     "API_DEVICE_STATE_ENDPOINT": "/v1/accounts/{}/metadevices/{}/state",
     "API_DEVICE_VERSIONS_ENDPOINT": "/v1/accounts/{}/devices/{}/versions",
+    # Per-device schedules (recurring on-device events, e.g. watering timers).
+    # Served by the API_DATA_HOST backend (set the Host header accordingly).
+    "API_DEVICE_SCHEDULES_ENDPOINT": "/v1/accounts/{}/metadevices/{}/schedules",
+    "API_DEVICE_SCHEDULE_ENDPOINT": "/v1/accounts/{}/metadevices/{}/schedules/{}",
     # Auth endpoints
     "AUTH_OPENID_ENDPOINT": "/protocol/openid-connect/auth",
     "AUTH_CODE_ENDPOINT": "/login-actions/authenticate",

--- a/tests/v1/controllers/test_schedules.py
+++ b/tests/v1/controllers/test_schedules.py
@@ -1,0 +1,133 @@
+"""Tests for the SchedulesController (per-device schedule client)."""
+
+import pytest
+from aioresponses import CallbackResult
+
+from aioafero.v1 import v1_const
+from aioafero.v1.models.schedules import DeviceSchedule, ScheduleEvent
+
+DATA_HOST = v1_const.AFERO_CLIENTS["hubspace"]["API_DATA_HOST"]
+
+
+def make_resp(mocker, json_data=None, status=200):
+    resp = mocker.MagicMock()
+    resp.status = status
+    resp.raise_for_status = mocker.MagicMock()
+    resp.json = mocker.AsyncMock(return_value=json_data)
+    return resp
+
+
+def raw_schedule(sched_id, instance, minutes, hour, minute):
+    return {
+        "id": sched_id,
+        "tag": '{"version":2}',
+        "deviceAttributeId": 49002,
+        "deviceAttributeData": "03FF04000134001E00",
+        "events": [
+            {
+                "enabled": True,
+                "timeType": "ABSOLUTE",
+                "daysOfWeek": ["MONDAY"],
+                "hour": hour,
+                "minute": minute,
+                "intervalDays": 0,
+                "semanticValues": [
+                    {"functionClass": "timer", "functionInstance": instance, "value": minutes}
+                ],
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def sched(mocked_bridge):
+    return mocked_bridge.schedules
+
+
+@pytest.mark.asyncio
+async def test_get_schedules(sched, mocker):
+    sched._bridge.request = mocker.AsyncMock(
+        return_value=make_resp(mocker, [raw_schedule("sch-1", "spigot-2", 30, 4, 0)])
+    )
+    out = await sched.get_schedules("dev-1")
+    assert len(out) == 1 and out[0].schedule_id == "sch-1"
+    assert out[0].events[0].function_instance == "spigot-2"
+    method, url = sched._bridge.request.call_args.args
+    assert method == "GET"
+    assert url.endswith("/v1/accounts/mocked-account-id/metadevices/dev-1/schedules")
+    # routed to the data host via the Host header
+    assert sched._bridge.request.call_args.kwargs["headers"]["host"] == DATA_HOST
+
+
+@pytest.mark.asyncio
+async def test_create_schedule(sched, mocker):
+    sched._bridge.request = mocker.AsyncMock(
+        return_value=make_resp(mocker, raw_schedule("sch-new", "spigot-1", 20, 6, 0))
+    )
+    obj = DeviceSchedule(events=[ScheduleEvent.weekly("spigot-1", 20, 6, 0, days=["MON"])])
+    result = await sched.create_schedule("dev-1", obj)
+    assert result.schedule_id == "sch-new"
+    method, url = sched._bridge.request.call_args.args
+    assert method == "POST"
+    assert url.endswith("/v1/accounts/mocked-account-id/metadevices/dev-1/schedules")
+    body = sched._bridge.request.call_args.kwargs["json"]
+    assert "scheduleId" not in body
+    assert body["events"][0]["semanticValues"][0]["functionInstance"] == "spigot-1"
+
+
+@pytest.mark.asyncio
+async def test_delete_schedule(sched, mocker):
+    sched._bridge.request = mocker.AsyncMock(return_value=make_resp(mocker, None, status=200))
+    await sched.delete_schedule("dev-1", "sch-1")
+    method, url = sched._bridge.request.call_args.args
+    assert method == "DELETE"
+    assert url.endswith("/v1/accounts/mocked-account-id/metadevices/dev-1/schedules/sch-1")
+
+
+@pytest.mark.asyncio
+async def test_add_event_merges(sched, mocker):
+    # GET existing (1 event) -> DELETE it -> POST merged (2 events)
+    sched._bridge.request = mocker.AsyncMock(
+        side_effect=[
+            make_resp(mocker, [raw_schedule("sch-old", "spigot-1", 20, 22, 0)]),  # GET
+            make_resp(mocker, None, status=200),  # DELETE
+            make_resp(mocker, raw_schedule("sch-new", "spigot-2", 30, 5, 30)),  # POST
+        ]
+    )
+    new_ev = ScheduleEvent.weekly("spigot-2", 30, 5, 30)
+    await sched.add_event("dev-1", new_ev)
+    assert sched._bridge.request.await_count == 3
+    # The POST body should carry BOTH the preserved + the new event
+    post_call = sched._bridge.request.await_args_list[2]
+    assert post_call.args[0] == "POST"
+    instances = [
+        sv["functionInstance"]
+        for e in post_call.kwargs["json"]["events"]
+        for sv in e["semanticValues"]
+    ]
+    assert instances == ["spigot-1", "spigot-2"]
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_e2e(bridge_with_acct, mock_aioresponse, mocker):
+    """Full stack: real request -> bearer + data-host Host header -> JSON body."""
+    bridge = bridge_with_acct
+    mocker.patch.object(bridge, "_account_id", "acct-1")
+    url = bridge.generate_api_url(
+        v1_const.AFERO_GENERICS["API_DEVICE_SCHEDULES_ENDPOINT"].format("acct-1", "dev-1")
+    )
+    captured = {}
+
+    def cb(called_url, **kwargs):
+        captured["headers"] = kwargs.get("headers", {})
+        captured["body"] = kwargs.get("json")
+        return CallbackResult(status=200, payload=raw_schedule("sch-9", "spigot-2", 30, 5, 30))
+
+    mock_aioresponse.post(url, callback=cb)
+    obj = DeviceSchedule(events=[ScheduleEvent.weekly("spigot-2", 30, 5, 30)])
+    result = await bridge.schedules.create_schedule("dev-1", obj)
+
+    assert result.schedule_id == "sch-9"
+    assert captured["headers"].get("Authorization") == "Bearer mock-token"
+    assert captured["headers"].get("host") == DATA_HOST
+    assert captured["body"]["events"][0]["hour"] == 5

--- a/tests/v1/controllers/test_valve.py
+++ b/tests/v1/controllers/test_valve.py
@@ -314,3 +314,25 @@ async def test_set_state_rain_delay(mocked_controller):
     await mocked_controller._bridge.async_block_until_done()
     dev = mocked_controller[valve.id]
     assert dev.rain_delay.active is True
+
+
+@pytest.mark.asyncio
+async def test_set_and_clear_rain_delay(mocked_controller):
+    await mocked_controller._bridge.events.generate_events_from_data(
+        [utils.create_hs_raw_from_device(valve)]
+    )
+    await mocked_controller._bridge.async_block_until_done()
+
+    await mocked_controller.set_rain_delay(valve.id, 1000, 2000)
+    await mocked_controller._bridge.async_block_until_done()
+    dev = mocked_controller[valve.id]
+    assert dev.rain_delay.active is True
+    assert dev.rain_delay.pauses == [
+        {"version": 1, "flags": 0, "startTime": 1000, "endTime": 2000}
+    ]
+
+    await mocked_controller.clear_rain_delay(valve.id)
+    await mocked_controller._bridge.async_block_until_done()
+    dev = mocked_controller[valve.id]
+    assert dev.rain_delay.active is False
+    assert dev.rain_delay.pauses == []

--- a/tests/v1/controllers/test_valve.py
+++ b/tests/v1/controllers/test_valve.py
@@ -174,3 +174,143 @@ async def test_set_state_invalid_instance(mocked_controller, caplog):
     )
     mocked_controller._bridge.request.assert_not_called()
     assert "No states to send. Skipping" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_initialize_battery_sensor(mocked_controller):
+    await mocked_controller.initialize_elem(valve)
+    dev = mocked_controller[valve.id]
+    assert "battery-level" in dev.sensors
+    assert dev.sensors["battery-level"].value == 100
+    assert dev.sensors["battery-level"].unit == "%"
+
+
+@pytest.mark.asyncio
+async def test_initialize_numbers(mocked_controller):
+    await mocked_controller.initialize_elem(valve)
+    dev = mocked_controller[valve.id]
+    # timer + max-on-time, one of each per spigot
+    assert set(dev.numbers) == {
+        ("timer", "spigot-1"),
+        ("timer", "spigot-2"),
+        ("max-on-time", "spigot-1"),
+        ("max-on-time", "spigot-2"),
+    }
+    max_on_1 = dev.numbers[("max-on-time", "spigot-1")]
+    assert max_on_1.value == 15
+    assert max_on_1.min == 1
+    assert max_on_1.max == 360
+    assert max_on_1.step == 1
+    assert max_on_1.unit == "minutes"
+    # timer range starts at 0 (idle) per the fixture
+    assert dev.numbers[("timer", "spigot-1")].value == 0
+    assert dev.numbers[("timer", "spigot-1")].min == 0
+
+
+@pytest.mark.asyncio
+async def test_initialize_rain_delay(mocked_controller):
+    await mocked_controller.initialize_elem(valve)
+    dev = mocked_controller[valve.id]
+    assert dev.rain_delay is not None
+    # Fixture: schedule-pause/active == "off", rain-delay array empty
+    assert dev.rain_delay.active is False
+    assert dev.rain_delay.pauses == []
+
+
+@pytest.mark.asyncio
+async def test_update_number(mocked_controller):
+    await mocked_controller._bridge.events.generate_events_from_data(
+        [utils.create_hs_raw_from_device(valve)]
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    dev_update = utils.create_devices_from_data("water-timer.json")[0]
+    utils.modify_state(
+        dev_update,
+        AferoState(
+            functionClass="max-on-time",
+            functionInstance="spigot-1",
+            value=30,
+            lastUpdateTime=0,
+        ),
+    )
+    updates = await mocked_controller.update_elem(dev_update)
+    dev = mocked_controller[valve.id]
+    assert dev.numbers[("max-on-time", "spigot-1")].value == 30
+    assert "number-('max-on-time', 'spigot-1')" in updates
+
+
+@pytest.mark.asyncio
+async def test_update_rain_delay_active(mocked_controller):
+    await mocked_controller._bridge.events.generate_events_from_data(
+        [utils.create_hs_raw_from_device(valve)]
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    dev_update = utils.create_devices_from_data("water-timer.json")[0]
+    utils.modify_state(
+        dev_update,
+        AferoState(
+            functionClass="schedule-pause",
+            functionInstance="active",
+            value="on",
+            lastUpdateTime=0,
+        ),
+    )
+    updates = await mocked_controller.update_elem(dev_update)
+    dev = mocked_controller[valve.id]
+    assert dev.rain_delay.active is True
+    assert updates == {"rain-delay"}
+
+
+@pytest.mark.asyncio
+async def test_update_rain_delay_pauses(mocked_controller):
+    await mocked_controller._bridge.events.generate_events_from_data(
+        [utils.create_hs_raw_from_device(valve)]
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    dev_update = utils.create_devices_from_data("water-timer.json")[0]
+    pause = {"startTime": 1700000000, "duration": 86400}
+    utils.modify_state(
+        dev_update,
+        AferoState(
+            functionClass="schedule-pause",
+            functionInstance="rain-delay",
+            value={
+                "schedule-pause-time-array": {"schedulePauseTimeArray": [pause]}
+            },
+            lastUpdateTime=0,
+        ),
+    )
+    updates = await mocked_controller.update_elem(dev_update)
+    dev = mocked_controller[valve.id]
+    assert dev.rain_delay.pauses == [pause]
+    assert updates == {"rain-delay"}
+
+
+@pytest.mark.asyncio
+async def test_set_state_number(mocked_controller):
+    await mocked_controller._bridge.events.generate_events_from_data(
+        [utils.create_hs_raw_from_device(valve)]
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    await mocked_controller.set_state(
+        valve.id,
+        numbers={
+            ("max-on-time", "spigot-1"): 30,
+            ("invalid", "state"): None,
+        },
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    dev = mocked_controller[valve.id]
+    assert dev.numbers[("max-on-time", "spigot-1")].value == 30
+
+
+@pytest.mark.asyncio
+async def test_set_state_rain_delay(mocked_controller):
+    await mocked_controller._bridge.events.generate_events_from_data(
+        [utils.create_hs_raw_from_device(valve)]
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    await mocked_controller.set_state(valve.id, rain_delay=True)
+    await mocked_controller._bridge.async_block_until_done()
+    dev = mocked_controller[valve.id]
+    assert dev.rain_delay.active is True

--- a/tests/v1/controllers/test_valve.py
+++ b/tests/v1/controllers/test_valve.py
@@ -336,3 +336,22 @@ async def test_set_and_clear_rain_delay(mocked_controller):
     dev = mocked_controller[valve.id]
     assert dev.rain_delay.active is False
     assert dev.rain_delay.pauses == []
+
+
+@pytest.mark.asyncio
+async def test_update_elem_adds_unknown_spigot(mocked_controller):
+    """A toggle for a spigot not seen at init must be added, not KeyError."""
+    await mocked_controller._bridge.events.generate_events_from_data(
+        [utils.create_hs_raw_from_device(valve)]
+    )
+    await mocked_controller._bridge.async_block_until_done()
+    dev_update = utils.create_devices_from_data("water-timer.json")[0]
+    dev_update.states.append(
+        AferoState(
+            functionClass="toggle", value="on", lastUpdateTime=0, functionInstance="spigot-3"
+        )
+    )
+    updates = await mocked_controller.update_elem(dev_update)
+    dev = mocked_controller[valve.id]
+    assert dev.open["spigot-3"].open is True
+    assert "open" in updates

--- a/tests/v1/data/water-timer-schedules.json
+++ b/tests/v1/data/water-timer-schedules.json
@@ -1,0 +1,67 @@
+[
+  {
+    "id": "00000000-0000-4000-8000-000000000001",
+    "tag": "{\"version\":2,\"outlet\":null,\"weekly\":null,\"index\":null}",
+    "deviceAttributeId": 49002,
+    "deviceAttributeData": "03FF042D0134001E0043020000EA07051C01000133003C00",
+    "events": [
+      {
+        "id": "00000000-0000-4000-8000-000000000002",
+        "enabled": true,
+        "timeType": "PERIODIC",
+        "daysOfWeek": [],
+        "startDateLocal": {
+          "year": 2026,
+          "month": 5,
+          "day": 28,
+          "hour": 1,
+          "minute": 0
+        },
+        "utc": false,
+        "intervalDays": 2,
+        "hour": 0,
+        "minute": 0,
+        "semanticValues": [
+          {
+            "id": "00000000-0000-4000-8000-000000000003",
+            "createdTimestampMs": 1700000000000,
+            "updatedTimestampMs": 1700000000000,
+            "functionClass": "timer",
+            "functionInstance": "spigot-1",
+            "value": 60
+          }
+        ],
+        "tag": "{\"version\":1,\"id\":\"00000000-0000-4000-8000-000000000004\"}"
+      },
+      {
+        "id": "00000000-0000-4000-8000-000000000005",
+        "enabled": true,
+        "timeType": "ABSOLUTE",
+        "daysOfWeek": [
+          "MONDAY",
+          "TUESDAY",
+          "WEDNESDAY",
+          "THURSDAY",
+          "FRIDAY",
+          "SATURDAY",
+          "SUNDAY"
+        ],
+        "utc": false,
+        "intervalDays": 0,
+        "hour": 4,
+        "minute": 45,
+        "semanticValues": [
+          {
+            "id": "00000000-0000-4000-8000-000000000006",
+            "createdTimestampMs": 1700000000000,
+            "updatedTimestampMs": 1700000000000,
+            "functionClass": "timer",
+            "functionInstance": "spigot-2",
+            "value": 30
+          }
+        ],
+        "tag": "{\"version\":1,\"id\":\"00000000-0000-4000-8000-000000000007\"}"
+      }
+    ]
+  }
+]

--- a/tests/v1/models/test_schedules.py
+++ b/tests/v1/models/test_schedules.py
@@ -1,0 +1,98 @@
+"""Tests for the per-device schedule data models."""
+
+import pytest
+
+from aioafero.v1.models.schedules import (
+    DeviceSchedule,
+    ScheduleEvent,
+    normalize_days,
+)
+
+
+def test_normalize_days():
+    assert normalize_days(["mon", "Wednesday", "FRI"]) == [
+        "MONDAY",
+        "WEDNESDAY",
+        "FRIDAY",
+    ]
+    with pytest.raises(ValueError, match="Unknown day"):
+        normalize_days(["Funday"])
+
+
+def test_event_weekly_builder():
+    ev = ScheduleEvent.weekly("spigot-1", 30, 5, 30, days=["mon", "wed", "fri"])
+    assert ev.time_type == "ABSOLUTE"
+    assert ev.days_of_week == ["MONDAY", "WEDNESDAY", "FRIDAY"]
+    assert ev.function_class == "timer" and ev.function_instance == "spigot-1"
+    # no days -> all 7
+    assert len(ScheduleEvent.weekly("spigot-2", 10, 6, 0).days_of_week) == 7
+    with pytest.raises(ValueError, match="hour must be"):
+        ScheduleEvent.weekly("spigot-1", 5, 25, 0)
+
+
+def test_event_to_afero():
+    ev = ScheduleEvent.weekly("spigot-2", 30, 4, 0, days=["MON"])
+    payload = ev.to_afero()
+    assert payload["timeType"] == "ABSOLUTE"
+    assert payload["daysOfWeek"] == ["MONDAY"]
+    assert payload["hour"] == 4 and payload["minute"] == 0
+    assert payload["semanticValues"] == [
+        {"functionClass": "timer", "functionInstance": "spigot-2", "value": 30}
+    ]
+    assert "startDateLocal" not in payload
+
+
+def test_event_periodic_round_trip():
+    data = {
+        "enabled": True,
+        "timeType": "PERIODIC",
+        "daysOfWeek": [],
+        "utc": False,
+        "intervalDays": 2,
+        "hour": 0,
+        "minute": 0,
+        "startDateLocal": {"year": 2026, "month": 5, "day": 28, "hour": 1, "minute": 0},
+        "semanticValues": [
+            {"functionClass": "timer", "functionInstance": "spigot-1", "value": 60}
+        ],
+    }
+    ev = ScheduleEvent.from_afero(data)
+    assert ev.time_type == "PERIODIC"
+    assert ev.interval_days == 2
+    assert ev.start_date_local["day"] == 28
+    assert ev.value == 60
+    assert ev.to_afero()["startDateLocal"] == data["startDateLocal"]
+
+
+def test_device_schedule_round_trip():
+    data = {
+        "id": "sch-1",
+        "tag": '{"version":2}',
+        "deviceAttributeId": 49002,
+        "deviceAttributeData": "03FF04000134001E00",
+        "events": [
+            {
+                "enabled": True,
+                "timeType": "ABSOLUTE",
+                "daysOfWeek": ["MONDAY", "WEDNESDAY"],
+                "hour": 6,
+                "minute": 30,
+                "intervalDays": 0,
+                "semanticValues": [
+                    {"functionClass": "timer", "functionInstance": "spigot-2", "value": 20}
+                ],
+            }
+        ],
+    }
+    sched = DeviceSchedule.from_afero(data)
+    assert sched.schedule_id == "sch-1"
+    assert sched.device_attribute_id == 49002
+    assert sched.device_attribute_data == "03FF04000134001E00"
+    assert len(sched.events) == 1
+    assert sched.events[0].function_instance == "spigot-2"
+
+    # to_afero omits scheduleId on create and never sends the derived hex
+    create_payload = DeviceSchedule(events=sched.events).to_afero()
+    assert "scheduleId" not in create_payload
+    assert "deviceAttributeData" not in create_payload
+    assert create_payload["events"][0]["semanticValues"][0]["value"] == 20

--- a/tests/v1/models/test_schedules.py
+++ b/tests/v1/models/test_schedules.py
@@ -1,5 +1,8 @@
 """Tests for the per-device schedule data models."""
 
+import json
+from pathlib import Path
+
 import pytest
 
 from aioafero.v1.models.schedules import (
@@ -7,6 +10,8 @@ from aioafero.v1.models.schedules import (
     ScheduleEvent,
     normalize_days,
 )
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 
 
 def test_normalize_days():
@@ -96,3 +101,42 @@ def test_device_schedule_round_trip():
     assert "scheduleId" not in create_payload
     assert "deviceAttributeData" not in create_payload
     assert create_payload["events"][0]["semanticValues"][0]["value"] == 20
+
+
+def test_from_afero_requires_semantic_values():
+    with pytest.raises(ValueError, match="missing semanticValues"):
+        ScheduleEvent.from_afero({"hour": 6, "minute": 0, "semanticValues": []})
+
+
+def test_real_water_timer_schedule_dump_parses():
+    """Parse a captured GET /schedules response from a live water timer.
+
+    Confirms the model handles the real wire shape: one schedule object holding
+    a mix of PERIODIC (every N days from a start date) and ABSOLUTE (weekly)
+    events, and that re-creating it drops the server-derived fields.
+    """
+    raw = json.loads((DATA_DIR / "water-timer-schedules.json").read_text())
+    schedules = [DeviceSchedule.from_afero(s) for s in raw]
+
+    assert len(schedules) == 1
+    sched = schedules[0]
+    assert sched.schedule_id == "00000000-0000-4000-8000-000000000001"
+    assert sched.device_attribute_id == 49002
+    assert {e.time_type for e in sched.events} == {"PERIODIC", "ABSOLUTE"}
+
+    periodic = next(e for e in sched.events if e.time_type == "PERIODIC")
+    assert periodic.interval_days == 2
+    assert periodic.start_date_local["hour"] == 1
+    assert periodic.function_instance == "spigot-1"
+    assert periodic.value == 60
+
+    absolute = next(e for e in sched.events if e.time_type == "ABSOLUTE")
+    assert absolute.hour == 4 and absolute.minute == 45
+    assert len(absolute.days_of_week) == 7
+    assert absolute.function_instance == "spigot-2"
+
+    payload = DeviceSchedule(events=sched.events, tag=sched.tag).to_afero()
+    assert "scheduleId" not in payload
+    assert "deviceAttributeData" not in payload
+    assert len(payload["events"]) == 2
+    assert payload["events"][0]["startDateLocal"]["day"] == 28

--- a/tests/v1/models/test_valve.py
+++ b/tests/v1/models/test_valve.py
@@ -45,3 +45,19 @@ def test_init_empty(empty_entity):
 
 def test_get_instance(populated_entity):
     assert populated_entity.get_instance("preset") == "preset-1"
+
+
+def test_rain_delay_defaults_none(empty_entity):
+    assert empty_entity.rain_delay is None
+
+
+def test_rain_delay_feature_api_value():
+    feat = features.RainDelayFeature(active=True, pauses=[{"a": 1}])
+    # api_value only toggles `active`; the pause array is app-managed.
+    assert feat.api_value == {
+        "functionClass": "schedule-pause",
+        "functionInstance": "active",
+        "value": "on",
+    }
+    feat.active = False
+    assert feat.api_value["value"] == "off"

--- a/tests/v1/models/test_valve.py
+++ b/tests/v1/models/test_valve.py
@@ -61,3 +61,25 @@ def test_rain_delay_feature_api_value():
     }
     feat.active = False
     assert feat.api_value["value"] == "off"
+
+
+def test_rain_delay_pause_window_builder():
+    w = features.RainDelayFeature.pause_window(1000, 2000)
+    assert w == {"version": 1, "flags": 0, "startTime": 1000, "endTime": 2000}
+
+
+def test_rain_delay_write_api_value():
+    feat = features.RainDelayFeature(
+        active=False,
+        pause_windows=[{"version": 1, "flags": 0, "startTime": 10, "endTime": 20}],
+    )
+    val = feat.api_value
+    assert isinstance(val, list) and len(val) == 2
+    active, arr = val
+    assert active == {"functionClass": "schedule-pause", "functionInstance": "active", "value": "on"}
+    assert arr["functionInstance"] == "rain-delay"
+    assert arr["value"]["schedule-pause-time-array"]["schedulePauseTimeArray"][0]["startTime"] == 10
+    # empty windows -> clear (active off, empty array)
+    clear = features.RainDelayFeature(active=True, pause_windows=[]).api_value
+    assert clear[0]["value"] == "off"
+    assert clear[1]["value"]["schedule-pause-time-array"]["schedulePauseTimeArray"] == []


### PR DESCRIPTION
## Summary

Adds first-class support for Hubspace water timers (Husky 2-spigot and similar Afero valves), in two parts:

### 1. Full valve state parsing
The `ValveController` previously parsed only `power`/`toggle`. This extends it to the rest of the water-timer functions:
- `battery-level` → sensor (`%`)
- `timer` and `max-on-time` per spigot → numbers (in the inherited `numbers` dict)
- `schedule-pause` (`active` + `rain-delay`) → a new `RainDelayFeature`
- `set_state` write paths for numbers + rain delay

Spigot parsing is instance-agnostic, so 1-, 2-, or N-spigot timers all work.

### 2. Per-device schedules (`bridge.schedules`)
Afero exposes recurring on-device schedules at `/v1/accounts/{accountId}/metadevices/{deviceId}/schedules` (served by the **data host** — addressed via the `Host` header, like `_fetch_device_states`). Each device holds a schedule object with a list of `events`; an event runs a function (e.g. a water timer's `timer`/`spigot-1`) for N minutes at a time, on `daysOfWeek` (ABSOLUTE) or every `intervalDays` (PERIODIC).

New `SchedulesController` + `DeviceSchedule`/`ScheduleEvent` models provide `get_schedules` / `create_schedule` / `delete_schedule`, an `add_event` merge helper, and a `ScheduleEvent.weekly(...)` builder. On create, only the semantic `events` are sent — the backend derives the on-device attribute blob.

## Testing
- New unit + model tests, plus end-to-end `aioresponses` coverage asserting the bearer + data-host `Host` headers and the JSON body.
- Full suite green (`pytest`: 550 passed, 1 skipped).
- **Verified live** against a real Husky 2-spigot timer account: parsing, schedule read, and schedule create/delete all confirmed (POST events-only → 201, backend derives the hex; DELETE → 200).

## Notes
- Schedules are intentionally a thin client over `request` (not a polled `BaseResourcesController`), since they aren't metadevice state.
- Happy to split parsing and schedules into separate PRs if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)